### PR TITLE
fixed --time switch to be more robust across platforms

### DIFF
--- a/bumps/cli.py
+++ b/bumps/cli.py
@@ -476,9 +476,9 @@ def main():
 
     if np.isfinite(float(opts.time)):
         import time
-        start_time = time.clock()
+        start_time = time.time()
         stop_time = start_time + float(opts.time)*3600
-        abort_test=lambda: time.clock() >= stop_time
+        abort_test=lambda: time.time() >= stop_time
     else:
         abort_test=lambda: False
 


### PR DESCRIPTION
On UNIX platforms time.clock() gives the processor time used on a particular thread. Time.time() is a more platform-independent way of using the actual wall time.