### PR TITLE
ENH: de candidates optimization

### DIFF
--- a/bumps/mystic/optimizer/de.py
+++ b/bumps/mystic/optimizer/de.py
@@ -141,9 +141,12 @@ def _candidates(pop, n, exclude=None):
     Select *n* random candidates from *pop*, not including the
     candidate at index *exclude*.
     """
-    selection = choose_without_replacement(len(pop)-1, n)
-    selection[selection>=exclude] += 1
-    return pop[selection]
+    idxs = list(range(len(pop)))
+    if exclude is not None:
+        idxs.pop(exclude)
+    np.random.shuffle(idxs)
+    return pop[idxs[:n]]
+
 
 ##########################################################################
 


### PR DESCRIPTION
This PR speeds the candidate selection up by a factor of 3 (from 66us to 20us for a (100, 20) population shape). It's also more pythonic.
The original `_candidates` function also had a bug. If `exclude is None` then the `selection[selection>=exclude]` line doesn't work:

    TypeError: '>=' not supported between instances of 'int' and 'NoneType'