### PR TITLE
Allow for numerical precision in test

### DIFF
--- a/bumps/wsolve.py
+++ b/bumps/wsolve.py
@@ -422,6 +422,7 @@ def test():
     """
     Check that results are correct for a known problem.
     """
+    from numpy.testing import assert_array_almost_equal_nulp
     x = np.array([0, 1, 2, 3, 4], 'd')
     y = np.array([2.5, 7.9, 13.9, 21.1, 44.4], 'd')
     dy = np.array([1.7, 2.4, 3.6, 4.8, 6.2], 'd')
@@ -446,7 +447,7 @@ def test():
     assert dperr < 1e-14, "||dp-Tdp||=%g" % dperr
     assert cierr < 1e-14, "||ci-Tci||=%g" % cierr
     assert pierr < 1e-14, "||pi-Tpi||=%g" % pierr
-    assert py == poly(px), "direct call to poly function fails"
+    assert_array_almost_equal_nulp(py, poly(px), nulp=8)
 
 if __name__ == "__main__":
     #test()


### PR DESCRIPTION
On x86 hardware (Python 2.7.14 on Debian's i386 port) the test against a known problem fails due to numerical precision. The attached patch uses `numpy`'s `assert_almost_equal` to test more robustly; one could reinvent an `assert abs(a - b) / a < delta` instead but since `numpy` is already used throughout, there's no harm in using it here too.

```Check that results are correct for a known problem. ... > /build/python-bumps-FiUVML/python-bumps-0.7.6/.pybuild/pythonX.Y_2.7/build/bumps/wsolve.py(447)test()
-> assert py == poly(px), "direct call to poly function fails"
(Pdb) py
array([ 13.18486645])
(Pdb) px
array([ 1.5])
(Pdb) poly(px)
array([ 13.18486645])
(Pdb) py - poly(px)
array([  1.77635684e-15])
```