### PR TITLE
Fix imports for matplotlib 2.2.2

### DIFF
--- a/bumps/gui/data_view.py
+++ b/bumps/gui/data_view.py
@@ -7,7 +7,7 @@ IS_MAC = (wx.Platform == '__WXMAC__')
 from numpy import inf
 
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-from matplotlib.backends.backend_wxagg import NavigationToolbar2Wx as Toolbar
+from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg as Toolbar
 
 # The Figure object is used to create backend-independent plot representations.
 from matplotlib.figure import Figure

--- a/bumps/gui/util.py
+++ b/bumps/gui/util.py
@@ -21,7 +21,7 @@ class EmbeddedPylab(object):
     The following example shows how to use the WxAgg backend in a wx panel::
 
         from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-        from matplotlib.backends.backend_wxagg import NavigationToolbar2Wx as Toolbar
+        from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg as Toolbar
         from matplotlib.figure import Figure
 
         class PlotPanel(wx.Panel):


### PR DESCRIPTION
The wx backend no longer exposes both NavigationToolbar2WxAgg and NavigationToolbar2Wx, generating an ImportError from gui/data_view.py