### PR TITLE
Use numpy legacy output format when doing doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.6"
+
+install:
+  - pip install matplotlib numpy nose scipy six sklearn
+
+script: ./test.py

--- a/bumps/numdifftools/core.py
+++ b/bumps/numdifftools/core.py
@@ -1358,6 +1358,12 @@ class Hessian(_Derivative):
 
 def test_docstrings():
     import doctest
+    # Whitespace changes between numpy 1.13 and 1.14 will cause the doctests
+    # to fail; when doctests are updated to 1.14 format, this can be removed.
+    try:    # CRUFT
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        pass
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/bumps/numdifftools/info.py
+++ b/bumps/numdifftools/info.py
@@ -86,6 +86,13 @@ scipy.misc.derivative
 
 def test_docstrings():
     import doctest
+    # Whitespace changes between numpy 1.13 and 1.14 will cause the doctests
+    # to fail; when doctests are updated to 1.14 format, this can be removed.
+    try:    # CRUFT
+        import numpy as np
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        pass
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 


### PR DESCRIPTION
numpy 1.14 changes the output format for printing and would break the doctests throughout; tell numpy to use the 1.13 format instead.

(This PR is built on top of the travis-ci one so that it is tested; I can rebase if needed so that it's only the single commit.)