### PR TITLE
Add to_dict() for serialization

### DIFF
--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -255,6 +255,14 @@ class BaseParameter(object):
     def __repr__(self):
         return "Parameter(%s)" % self
 
+    def to_dict(self):
+        """
+        Return a dict represention of the object.
+        """
+        return dict(name=self.name, type=type(self).__name__,
+                    value=self.value, fixed=self.fixed,
+                    bounds=dict(type=type(self._bounds).__name__, limits=self._bounds.limits))
+
 
 class Constant(BaseParameter):
     """


### PR DESCRIPTION
I added a `to_dict()` to `BaseParameter` so that `refl1d` can serialize some of its objects.

Note: I went with the `to_dict` name mostly because it can then be used for other purposes than just producing json files. Adding extra info such as class name seemed to make dictionaries reasonable.