### PR TITLE
Drop Python 2.7 support from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.6"
 
 install:


### PR DESCRIPTION
The package uses the matrix multiplication infix operator which is Python 3.5
or later and that makes the most recent 0.7.17 release Python 3.5+. I guess that makes it time to stop testing against Python 2.7.

(There is more that can be done to drop old code, but this is the first step)