### PR TITLE
Make sphinx nitpick-happy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
       if: matrix.cfg.doc == 1
       run: |
         python -m pip install sphinx
-        make -j 4 -C doc SPHINXOPTS="-W --keep-going" html
+        make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,6 +63,10 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
 nitpick_ignore = [
     ('py:class', 'type'),
     ('py:class', 'object'),
+    ("py:class", "numpy.ndarray"),
+    ("py:class", "np.ndarray"),
+    ("py:class", "Real"),
+    ("py:class", "Integral"),
     ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The bumps `doc/Makefile` sets `-n` in `SPHINXOPTS` but CI does not test it with that. SasView CI uses the Makefile and so fails when sphinx finds nitpicks that have never been tested in CI.

This PR
* enables `-n` in the CI
* fixes some nitpicks that sphinx is currently complaining about.

(Hopefully this is enough to get SasView CI passing again)