### PR TITLE
Use to array instead of matrix

### DIFF
--- a/bumps/wsolve.py
+++ b/bumps/wsolve.py
@@ -29,7 +29,7 @@ Weighted system::
 
     >>> import numpy as np
     >>> from bumps import wsolve
-    >>> A = np.matrix("1,2,3;2,1,3;1,1,1",'d').A
+    >>> A = np.array([[1,2,3],[2,1,3],[1,1,1]], dtype='d')
     >>> dy = [0.2,0.01,0.1]
     >>> y = [ 14.16, 13.01, 6.15]
     >>> s = wsolve.wsolve(A,y,dy)


### PR DESCRIPTION
Running tests gave the following warning 

```
bumps/wsolve.py::bumps.wsolve
  <doctest bumps.wsolve[2]>:1: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
```

This was from some documentation code, that gave an example using the [now deprecated](https://stackoverflow.com/questions/53254738/deprecation-status-of-the-numpy-matrix-class) matrix class instead of `np.array`. 

I have made a like for like change to the doc string. 