### PR TITLE
Allow numba models

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: ubuntu-latest, py: 2.7 }
+          #- { os: ubuntu-latest, py: 2.7 }
           - { os: ubuntu-latest, py: 3.6 }
           - { os: ubuntu-latest, py: 3.8, doc: 1 }
           - { os: windows-latest, py: 3.8 }

--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -76,16 +76,11 @@ def _parse_pars(fn, init=None, skip=0, name=""):
     """
     sig = inspect.signature(fn)
     params = sig.parameters.values()
-    #pnames, vararg, varkw, pvalues = inspect.getfullargspec(fn)
     pnames = [p.name for p in params]
-    pvalues = [p.default for p in params]
-    vararg = [p for p in params if p.kind.name == 'VAR_POSITIONAL']
-    varkw = [p for p in params if p.kind.name == 'VAR_KEYWORD']
-
-    if vararg or varkw:
-        raise TypeError(
-            "Function %r cannot have *args or **kwargs in declaration"
-            % fn.__name__)
+    
+    valid = [p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD) for p in params]
+    if not all(valid):
+        raise TypeError(f"Only positional and keyword arguments allowed for {fn.__name__}")
 
     # TODO: need "self" handling for passed methods
     # Skip the first argument if it is x or maybe skip x, y.

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -783,9 +783,9 @@ def load_problem(filename, options=None):
     """
     # Allow relative imports from the bumps model
     module_name = os.path.splitext(os.path.basename(filename))[0]
-    package = util.relative_import(filename, module_name=module_name)
+    module = util.relative_import(filename, module_name=module_name)
 
-    ctx = dict(__file__=filename, __package__=package, __name__=module_name)
+    ctx = dict(__file__=filename, __package__=module, __name__=module_name)
     old_argv = sys.argv
     sys.argv = [filename] + options if options else [filename]
     source = open(filename).read()

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -782,10 +782,10 @@ def load_problem(filename, options=None):
     Raises ValueError if the script does not define problem.
     """
     # Allow relative imports from the bumps model
-    module = os.path.splitext(os.path.basename(filename))[0]
-    package = util.relative_import(filename, package=module)
+    module_name = os.path.splitext(os.path.basename(filename))[0]
+    package = util.relative_import(filename, module_name=module_name)
 
-    ctx = dict(__file__=filename, __package__=package, __name__=module)
+    ctx = dict(__file__=filename, __package__=package, __name__=module_name)
     old_argv = sys.argv
     sys.argv = [filename] + options if options else [filename]
     source = open(filename).read()

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -782,8 +782,8 @@ def load_problem(filename, options=None):
     Raises ValueError if the script does not define problem.
     """
     # Allow relative imports from the bumps model
-    package = util.relative_import(filename)
     module = os.path.splitext(os.path.basename(filename))[0]
+    package = util.relative_import(filename, package=module)
 
     ctx = dict(__file__=filename, __package__=package, __name__=module)
     old_argv = sys.argv

--- a/bumps/util.py
+++ b/bumps/util.py
@@ -97,8 +97,9 @@ def kbhit():
 
 
 class DynamicPackage(object):
-    def __init__(self, path):
+    def __init__(self, path, name):
        self.__path__ = [path]
+       self.__name__ = name
 
 
 def relative_import(filename, package="relative_import"):
@@ -116,7 +117,7 @@ def relative_import(filename, package="relative_import"):
             and not isinstance(sys.modules[package], DynamicPackage)):
         raise ImportError("relative import would override the existing package %s. Use another name"
                           % package)
-    sys.modules[package] = DynamicPackage(path)
+    sys.modules[package] = DynamicPackage(path, package)
     return package
 
 

--- a/bumps/util.py
+++ b/bumps/util.py
@@ -7,6 +7,8 @@ __all__ = ["kbhit", "profile", "pushdir", "push_seed", "redirect_console"]
 
 import sys
 import os
+import types
+
 try:  # CRUFT: python 2.x
     from cStringIO import StringIO
 except ImportError:
@@ -96,15 +98,15 @@ def kbhit():
         return sys.stdin in i
 
 
-class DynamicPackage(object):
+class DynamicModule(types.ModuleType):
     def __init__(self, path, name):
        self.__path__ = [path]
        self.__name__ = name
 
 
-def relative_import(filename, package="relative_import"):
+def relative_import(filename, module_name="relative_import"):
     """
-    Define an empty package allowing relative imports from a script.
+    Define an empty module allowing relative imports from a script.
 
     By setting :code:`__package__ = relative_import(__file__)` at the top of
     your script file you can even run your model as a python script.  So long
@@ -113,12 +115,12 @@ def relative_import(filename, package="relative_import"):
     can be used both within and outside of bumps.
     """
     path = os.path.dirname(os.path.abspath(filename))
-    if (package in sys.modules
-            and not isinstance(sys.modules[package], DynamicPackage)):
-        raise ImportError("relative import would override the existing package %s. Use another name"
-                          % package)
-    sys.modules[package] = DynamicPackage(path, package)
-    return package
+    if (module_name in sys.modules
+            and not isinstance(sys.modules[module_name], DynamicModule)):
+        raise ImportError("relative import would override the existing module %s. Use another name"
+                          % module_name)
+    sys.modules[module_name] = DynamicModule(path, module_name)
+    return module_name
 
 
 class redirect_console(object):


### PR DESCRIPTION
Apply some updates, replacing deprecated inspect.getargspec with inspect.signature and apply a __name__ attribute to the DynamicPackage created when the model is loaded.  These two fixes together enable @numba.jit functions in a user model.

Addresses #65 