### PR TITLE
add a 'source' parameter to signal.update_model

### DIFF
--- a/bumps/gui/app_panel.py
+++ b/bumps/gui/app_panel.py
@@ -337,9 +337,9 @@ class AppPanel(wx.Panel):
     def OnModelNew(self, model):
         self.set_model(model)
 
-    def OnModelChange(self, model):
+    def OnModelChange(self, model, source=None):
         for v in self.view.values():
-            if hasattr(v, 'update_model'):
+            if getattr(v, 'title', '') != source and hasattr(v, 'update_model'):
                 v.update_model(model)
 
     def OnModelSetpar(self, model):

--- a/bumps/gui/parameter_view.py
+++ b/bumps/gui/parameter_view.py
@@ -36,6 +36,7 @@ from .util import nice
 from . import signal
 
 IS_MAC = (wx.Platform == '__WXMAC__')
+VIEW_NAME = "Parameters"
 
 class ParameterCategory(object):
     def __init__(self, name):
@@ -219,13 +220,13 @@ class ParametersModel(dv.PyDataViewModel):
             # update; parameter values didn't change, so dirty=False, and
             # model.model_update() will not be called and the theory value
             # will not be re-computed.
-            signal.update_model(model=self.model, dirty=False)
+            signal.update_model(model=self.model, dirty=False, source=VIEW_NAME)
         else:
             signal.update_parameters(model=self.model, delay=1)
         return True
 
 class ParameterView(wx.Panel):
-    title = 'Parameters'
+    title = VIEW_NAME
     default_size = (640,500)
     def __init__(self, *args, **kw):
         wx.Panel.__init__(self, *args, **kw)

--- a/bumps/gui/signal.py
+++ b/bumps/gui/signal.py
@@ -20,15 +20,16 @@ def model_new(model):
     wx.CallAfter(send, 'model.new', model=model)
 
 
-def update_model(model, dirty=True):
+def update_model(model, dirty=True, source=None):
     """
     Inform all views that the model structure has changed.  This calls
     model.model_reset() to reset the fit parameters and constraints.
+    Include a source if debouncing is needed.
     """
     model.model_reset()  #
     if dirty:
         model.model_update()
-    wx.CallAfter(send, 'model.update_structure', model=model)
+    wx.CallAfter(send, 'model.update_structure', model=model, source=source)
 
 
 _DELAYED_SIGNAL = {}


### PR DESCRIPTION
...so that updates can be ignored for same-source

An alternative to this is to add an argument to every view's update_model method that contains extra information, like the source of the event, and the update_model methods could then use that information if they want.

In this version, if you pass a "source" parameter to signal.update_model,  bumps.app_panel will not run view.update_model for any view where the title matches. "source"