### PR TITLE
Mark inner loop variables as private for openmp in bounds calculations

### DIFF
--- a/bumps/dream/compiled.c
+++ b/bumps/dream/compiled.c
@@ -398,7 +398,7 @@ void bounds_reflect(int Nchain, int Nvar, double pop[], double low[], double hig
     int k, p, idx;
 
     #ifdef _OPENMP
-    #pragma omp parallel for private(idx)
+    #pragma omp parallel for private(idx, k)
     #endif
     for (p=0; p < Nchain; p++) {
         for (k=0; k < Nvar; k++) {
@@ -421,7 +421,7 @@ void bounds_clip(int Nchain, int Nvar, double pop[], double low[], double high[]
     int k, p, idx;
 
     #ifdef _OPENMP
-    #pragma omp parallel for private(idx)
+    #pragma omp parallel for private(idx, k)
     #endif
     for (p=0; p < Nchain; p++) {
         for (k=0; k < Nvar; k++) {
@@ -441,7 +441,7 @@ void bounds_fold(int Nchain, int Nvar, double pop[], double low[], double high[]
     int k, p, idx;
 
     #ifdef _OPENMP
-    #pragma omp parallel for private(idx)
+    #pragma omp parallel for private(idx, k)
     #endif
     for (p=0; p < Nchain; p++) {
         for (k=0; k < Nvar; k++) {
@@ -472,7 +472,7 @@ void bounds_random(int Nchain, int Nvar, double pop[], double low[], double high
     int k, p, idx;
 
     #ifdef _OPENMP
-    #pragma omp parallel for private(idx)
+    #pragma omp parallel for private(idx, k)
     #endif
     for (p=0; p < Nchain; p++) {
         for (k=0; k < Nvar; k++) {


### PR DESCRIPTION
In packaging bumps 0.9.0, we noticed that the dream/bounds.py tests were failing; the failures were not always identical but were always when the bounds were reflected or folded on the multidimensional test at `bounds.py:207`, with 1 or 2 of the vectors not having the bounds applied to them correctly, and so the `norm` not evaluating to `0`.

After much gnashing of teeth, we found that the failures often went away when running within the debugger,  could be suppressed entirely if the C bounds code was not used (by setting `dll=None` in the python module), and could also be suppressed by preventing OpenMP from doing any parallelisation (by setting `OMP_NUM_THREADS=1` in the environment.

Looking at the C functions `bounds_reflect`, `bounds_clip`, `bounds_fold`, they each contain nested loops that are being parallelised using `#pragma omp parallel for private(idx)`. However, for nested loops, the inner loop variable needs to be private, else the parallelised loops will interfere with each other and return early. OPENMP automatically marks any variables that are declared within the parallelised block as being private but if the inner loop variable is declared at the top of the function, then this does not happen. The attached patch just makes the inner loop variable thread-private too.

It appears that this failure has been around for a while; I can see in the packaging git log that the tests of the `bumps.dream` module were disabled back in 2018 with a commit message citing a failure at the same location; it was only in switching from nose to pytest for 0.9.0 that it came to light again.

I assume that OpenMP is automatically selecting only one thread on GitHub CI which is why the failure is not seen there.

Test logs below:

**Failing**
```
$ py.test -v --no-cov ./bumps/dream/bounds.py     
============================================== test session starts ==============================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: …/bumps, configfile: pytest.ini
plugins: cov-3.0.0
collected 1 item                                                                                                

bumps/dream/bounds.py::test FAILED                                                                        [100%]

=================================================== FAILURES ====================================================
_____________________________________________________ test ______________________________________________________

    def test():
        """bounds handlers test"""
        from numpy.linalg import norm
        from numpy import array
    
        bounds = list(zip([5, 10], [-inf, -10], [-5, inf], [-inf, inf]))
        v = np.ascontiguousarray([6, -12, 6, -12], 'd')
        for t in 'none', 'reflect', 'clip', 'fold', 'randomize':
            assert norm(make_bounds_handler(bounds, t).apply(v+0) - v) == 0
        v = np.ascontiguousarray([12, 12, -12, -12], 'd')
        for t in 'none', 'reflect', 'clip', 'fold':
            w = make_bounds_handler(bounds, t)
>           assert norm(w(array([v, v, v])) - w.apply(v+0)) == 0
E           assert 23.173260452512935 == 0
E            +  where 23.173260452512935 = <function norm at 0x7fd273866a70>((array([[ 10., -10.,  -5., -12.],\n       [ 10., -10.,  -5., -12.],\n       [ 12.,  12., -12., -12.]]) - array([ 10., -10.,  -5., -12.])))
E            +    where array([[ 10., -10.,  -5., -12.],\n       [ 10., -10.,  -5., -12.],\n       [ 12.,  12., -12., -12.]]) = <bumps.dream.bounds.ClipBounds object at 0x7fd272bde470>(array([[ 10., -10.,  -5., -12.],\n       [ 10., -10.,  -5., -12.],\n       [ 12.,  12., -12., -12.]]))
E            +      where array([[ 10., -10.,  -5., -12.],\n       [ 10., -10.,  -5., -12.],\n       [ 12.,  12., -12., -12.]]) = <built-in function array>([array([ 12.,  12., -12., -12.]), array([ 12.,  12., -12., -12.]), array([ 12.,  12., -12., -12.])])
E            +    and   array([ 10., -10.,  -5., -12.]) = <bound method ClipBounds.apply of <bumps.dream.bounds.ClipBounds object at 0x7fd272bde470>>((array([ 12.,  12., -12., -12.]) + 0))
E            +      where <bound method ClipBounds.apply of <bumps.dream.bounds.ClipBounds object at 0x7fd272bde470>> = <bumps.dream.bounds.ClipBounds object at 0x7fd272bde470>.apply

bumps/dream/bounds.py:207: AssertionError
============================================ short test summary info ============================================
FAILED bumps/dream/bounds.py::test - assert 23.173260452512935 == 0
=============================================== 1 failed in 3.00s ===============================================
```

**Failure suppressed by forcing single threading**
```
$ OMP_NUM_THREADS=1 py.test -v --no-cov ./bumps/dream/bounds.py
============================================== test session starts ==============================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: …/bumps, configfile: pytest.ini
plugins: cov-3.0.0
collected 1 item                                                                                                

bumps/dream/bounds.py::test PASSED                                                                        [100%]

=============================================== 1 passed in 2.83s ===============================================
```

**Test passing after adding this patch**
```
$ py.test -v --no-cov ./bumps/dream/bounds.py
============================================== test session starts ==============================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: …/bumps, configfile: pytest.ini
plugins: cov-3.0.0
collected 1 item                                                                                                

bumps/dream/bounds.py::test PASSED                                                                        [100%]

=============================================== 1 passed in 2.97s ===============================================
```
