### PR TITLE
Always run CI jobs, not only on commits to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Noting the comment in #100 about CI not running tests for the C code, I thought I'd look at fixing that. However, I can't actually test out changes to CI until after opening a PR, which means that changes don't get tested by CI until after the project owners start getting pestered by notifications about PRs being open.

It's more standard that new code should be tested on CI *prior* to making a pull request, that way the automated tests are completed in advance the initial PR is of better quality.