### PR TITLE
Drop unsupported Python 3.6, add supported 3.10, 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         cfg:
           #- { os: ubuntu-latest, py: 2.7 }
           - { os: ubuntu-latest, py: 3.8, doc: 1 }
+          - { os: ubuntu-latest, py: "3.10" }
+          - { os: ubuntu-latest, py: 3.11 }
           - { os: windows-latest, py: 3.8 }
           - { os: macos-latest, py: 3.8 }
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         cfg:
           #- { os: ubuntu-latest, py: 2.7 }
-          - { os: ubuntu-latest, py: 3.6 }
           - { os: ubuntu-latest, py: 3.8, doc: 1 }
           - { os: windows-latest, py: 3.8 }
           - { os: macos-latest, py: 3.8 }


### PR DESCRIPTION
CI is currently failing because:
- Python 3.6 is no longer available in the `ubuntu-latest` image and so CI fail there.
- bumps is not compatible with scipy 1.10
- bumps is not compatible with numpy 1.24

It's also very much time to add some newer Python 3 releases to the CI matrix.

This PR doesn't fix CI, it's only addressing the first point of the 3 failures. I'll put the other 2 into a new issue.