### PR TITLE
Update code and tests for scipy 1.10 and numpy 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         cfg:
           #- { os: ubuntu-latest, py: 2.7 }
-          - { os: ubuntu-latest, py: 3.6 }
           - { os: ubuntu-latest, py: 3.8, doc: 1 }
           - { os: windows-latest, py: 3.8 }
           - { os: macos-latest, py: 3.8 }

--- a/bumps/dream/entropy.py
+++ b/bumps/dream/entropy.py
@@ -859,8 +859,14 @@ class MVNSingular:
         return self.dist.rvs(size=size)
 
     def entropy(self, N=10000):
+        # scipy 1.10 changed Covariance handling in stats, allow for that change
+        if hasattr(self.dist, 'cov'):
+            cov = self.dist.cov
+        else:
+            cov = self.dist.cov_object.covariance
+
         with np.errstate(divide='ignore'):
-            return 0.5*log(np.linalg.det((2*pi*np.e)*self.dist.cov))
+            return 0.5*log(np.linalg.det((2*pi*np.e)*cov))
 
 class GaussianMixture:
     def __init__(self, w, mu=None, sigma=None):

--- a/bumps/mpfit.py
+++ b/bumps/mpfit.py
@@ -141,7 +141,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
     # stop the calculation.
     status = 0
     if (dojac):
-       pderiv = numpy.zeros([len(x), len(p)], numpy.float)
+       pderiv = numpy.zeros([len(x), len(p)], numpy.float64)
        for j in range(len(p)):
          pderiv[:,j] = FGRAD(x, p, j)
     else:
@@ -279,7 +279,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 
    import mpfit
    import numpy
-   x = numpy.arange(100, numpy.float)
+   x = numpy.arange(100, numpy.float64)
    p0 = [5.7, 2.2, 500., 1.5, 2000.]
    y = ( p[0] + p[1]*[x] + p[2]*[x**2] + p[3]*numpy.sqrt(x) +
          p[4]*numpy.log(x))
@@ -897,8 +897,8 @@ Keywords:
             self.errmsg = 'ERROR: either P or PARINFO(*)["value"] must be supplied.'
             return
 
-      ## Make sure parameters are numpy arrays of type numpy.float
-      xall = numpy.asarray(xall, numpy.float)
+      ## Make sure parameters are numpy arrays of type numpy.float64
+      xall = numpy.asarray(xall, numpy.float64)
 
       npar = len(xall)
       self.fnorm  = -1.
@@ -995,8 +995,8 @@ Keywords:
          if (len(wh) > 0): return
          self.errmsg = ''
 
-      # Make sure x is a numpy array of type numpy.float
-      x = numpy.asarray(x, numpy.float)
+      # Make sure x is a numpy array of type numpy.float64
+      x = numpy.asarray(x, numpy.float64)
 
       [self.status, fvec] = self.call(fcn, self.params, functkw)
       if (self.status < 0):
@@ -1329,14 +1329,14 @@ Keywords:
 
             ## Fill in actual covariance matrix, accounting for fixed
             ## parameters.
-            self.covar = numpy.zeros([nn, nn], numpy.float)
+            self.covar = numpy.zeros([nn, nn], numpy.float64)
             for i in range(n):
                indices = ifree+ifree[i]*n
                numpy.put(self.covar, indices, cv[:,i])
 
             ## Compute errors in parameters
             catch_msg = 'computing parameter errors'
-            self.perror = numpy.zeros(nn, numpy.float)
+            self.perror = numpy.zeros(nn, numpy.float64)
             d = numpy.diagonal(self.covar).copy()
             wh, = numpy.nonzero(d >= 0)
             if len(wh) > 0:
@@ -1408,9 +1408,9 @@ Keywords:
       test = default
       if isinstance(default, list): test=default[0]
       if isinstance(test, int):
-         values = numpy.asarray(values, numpy.int)
+         values = numpy.asarray(values, numpy.int32)
       elif isinstance(test, float):
-         values = numpy.asarray(values, numpy.float)
+         values = numpy.asarray(values, numpy.float64)
       return(values)
 
 
@@ -1482,7 +1482,7 @@ Keywords:
       ## Compute analytical derivative if requested
       if (autoderivative == 0):
          mperr = 0
-         fjac = numpy.zeros(nall, numpy.float)
+         fjac = numpy.zeros(nall, numpy.float64)
          numpy.put(fjac, ifree, 1.0)  ## Specify which parameters need derivatives
          [status, fp, pderiv] = self.call(fcn, xall, functkw, fjac=fjac)
 
@@ -1502,7 +1502,7 @@ Keywords:
             fjac.shape = [m, n]
             return(fjac)
 
-      fjac = numpy.zeros([m, n], numpy.float)
+      fjac = numpy.zeros([m, n], numpy.float64)
 
       h = eps * abs(x)
 
@@ -1687,7 +1687,7 @@ Keywords:
       n = sz[1]
 
       ## Compute the initial column norms and initialize arrays
-      acnorm = numpy.zeros(n, numpy.float)
+      acnorm = numpy.zeros(n, numpy.float64)
       for j in range(n):
          acnorm[j] = self.enorm(a[:,j])
       rdiag = acnorm.copy()


### PR DESCRIPTION
This PR addresses the (in)compatibility of bumps with scipy 1.10 and numpy 1.24.

* Include the updates required for scipy 1.10 as discussed in #118 (thanks to Drew Parsons for the patch via the Debian packaging for bumps)
* Update np.float and np.int to used defined sizes for numpy 1.24 compatibility
* cherry-pick commit to drop Python 3.6 from CI; this is necessary to get *any* CI to pass at present as there python 3.6 is not available in the CI matrix any more. (Cherry-picked from #117; as noted there, CI for master currently fails and merging this commit is a prereq to get anything useful out of CI)

Closes: #118 