### PR TITLE
Fixed Improper Method Call: `__getitem__`

### DIFF
--- a/bumps/dream/corrplot.py
+++ b/bumps/dream/corrplot.py
@@ -41,12 +41,13 @@ class Corr2d(object):
     def R(self):
         return np.corrcoef(self.data)
 
-    def __getitem__(self, i, j):
+    def __getitem__(self, key):
         """
         Retrieve correlation histogram for data[i] X data[j].
 
         Returns bin i edges, bin j edges, and histogram
         """
+        i, j = key
         return self.hists[i, j]
 
     def plot(self, title=None):


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [corrplot.py](https://github.com/bumps/bumps/tree/master/bumps/dream/corrplot.py#L44), class: Corr2d, there is a special method [`__getitem__`](https://docs.python.org/3/reference/datamodel.html#object.__getitem__) that contains an unexpected number of parameters. Each call to this method will result in a TypeError. iCR suggested that special methods should have an expected number of parameters. More infomation can be found in the Python [documentation on the various special method](https://docs.python.org/3/reference/datamodel.html#special-method-names).

Since the implementation of method `__getitem__` requires the use of two indices (i, j), I've converted the parameter to a tuple. In this way, the method is consistent with the documentation and the implementation doesn't require any overhead.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
