### PR TITLE
Numpy 2.0 compat

### DIFF
--- a/bumps/dream/formatnum.py
+++ b/bumps/dream/formatnum.py
@@ -41,7 +41,7 @@ Example::
 from __future__ import division
 import math
 
-from numpy import isinf, isnan, inf, NaN
+from numpy import isinf, isnan, inf, nan
 
 __all__ = ['format_value', 'format_uncertainty',
            'format_uncertainty_compact', 'format_uncertainty_pm',
@@ -295,10 +295,10 @@ def test_compact():
     # non-finite values
     assert value_str(-inf, None) == "-inf"
     assert value_str(inf, None) == "inf"
-    assert value_str(NaN, None) == "NaN"
+    assert value_str(nan, None) == "NaN"
 
     # bad or missing uncertainty
-    assert value_str(-1.23567, NaN) == "-1.23567"
+    assert value_str(-1.23567, nan) == "-1.23567"
     assert value_str(-1.23567, -inf) == "-1.23567"
     assert value_str(-1.23567, -0.1) == "-1.23567"
     assert value_str(-1.23567, 0) == "-1.23567"
@@ -427,10 +427,10 @@ def test_pm():
     # non-finite values
     assert value_str(-inf, None) == "-inf"
     assert value_str(inf, None) == "inf"
-    assert value_str(NaN, None) == "NaN"
+    assert value_str(nan, None) == "NaN"
 
     # bad or missing uncertainty
-    assert value_str(-1.23567, NaN) == "-1.23567"
+    assert value_str(-1.23567, nan) == "-1.23567"
     assert value_str(-1.23567, -inf) == "-1.23567"
     assert value_str(-1.23567, -0.1) == "-1.23567"
     assert value_str(-1.23567, 0) == "-1.23567"

--- a/bumps/dream/walk.py
+++ b/bumps/dream/walk.py
@@ -10,12 +10,12 @@ from __future__ import division
 
 __all__ = ["walk"]
 
-from numpy import asarray, ones_like, NaN, isnan
+from numpy import asarray, ones_like, nan, isnan
 
 from . import util
 
 
-def walk(n=1000, mu=0, sigma=1, alpha=0.01, s0=NaN):
+def walk(n=1000, mu=0, sigma=1, alpha=0.01, s0=nan):
     """
     Mean reverting random walk.
 

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -59,7 +59,7 @@ import logging
 import warnings
 
 import numpy as np
-from numpy import inf, isnan, NaN
+from numpy import inf, isnan, nan
 
 from . import parameter, bounds as mbounds
 from .parameter import to_dict
@@ -510,7 +510,7 @@ class BaseFitProblem(object):
             info = (traceback.format_exc(),
                     parameter.summarize(self._parameters))
             logging.error("\n".join(info))
-            return NaN, NaN, NaN
+            return nan, nan, nan
 
     def __call__(self, pvec=None):
         """
@@ -772,7 +772,7 @@ def nllf_scale(problem):
     measurements.  To first approximation, the uncertainty in $\chi^2_N$
     is $k/(n-k)$
     """
-    dof = getattr(problem, 'dof', np.NaN)
+    dof = getattr(problem, 'dof', np.nan)
     if dof <= 0 or np.isnan(dof) or np.isinf(dof):
         return 1., 0.
     else:

--- a/bumps/formatnum.py
+++ b/bumps/formatnum.py
@@ -41,7 +41,7 @@ Example::
 from __future__ import division
 import math
 
-from numpy import isinf, isnan, inf, NaN
+from numpy import isinf, isnan, inf, nan
 
 __all__ = ['format_value', 'format_uncertainty',
            'format_uncertainty_compact', 'format_uncertainty_pm',
@@ -294,10 +294,10 @@ def test_compact():
     # non-finite values
     assert value_str(-inf, None) == "-inf"
     assert value_str(inf, None) == "inf"
-    assert value_str(NaN, None) == "NaN"
+    assert value_str(nan, None) == "NaN"
 
     # bad or missing uncertainty
-    assert value_str(-1.23567, NaN) == "-1.23567"
+    assert value_str(-1.23567, nan) == "-1.23567"
     assert value_str(-1.23567, -inf) == "-1.23567"
     assert value_str(-1.23567, -0.1) == "-1.23567"
     assert value_str(-1.23567, 0) == "-1.23567"
@@ -426,10 +426,10 @@ def test_pm():
     # non-finite values
     assert value_str(-inf, None) == "-inf"
     assert value_str(inf, None) == "inf"
-    assert value_str(NaN, None) == "NaN"
+    assert value_str(nan, None) == "NaN"
 
     # bad or missing uncertainty
-    assert value_str(-1.23567, NaN) == "-1.23567"
+    assert value_str(-1.23567, nan) == "-1.23567"
     assert value_str(-1.23567, -inf) == "-1.23567"
     assert value_str(-1.23567, -0.1) == "-1.23567"
     assert value_str(-1.23567, 0) == "-1.23567"

--- a/bumps/pytwalk.py
+++ b/bumps/pytwalk.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 __all__ = ["pytwalk"]
 
 from numpy.random import uniform, normal
-from numpy import ones, zeros, cumsum, shape, mat, cov, mean, ceil, matrix, sqrt
+from numpy import ones, zeros, cumsum, shape, asmatrix as mat, cov, mean, ceil, matrix, sqrt
 from numpy import floor, exp, log, sum, pi, arange
 
 # Some auxiliary functions and constants

--- a/bumps/simplex.py
+++ b/bumps/simplex.py
@@ -141,7 +141,7 @@ def simplex(f, x0=None, bounds=None, radius=0.05,
 
     """
     fcalls, func = wrap_function(f, bounds)
-    x0 = np.asfarray(x0).flatten()
+    x0 = np.asarray(x0, dtype=float).flatten()
     # print "x0",x0
     N = len(x0)
     rank = len(x0.shape)


### PR DESCRIPTION
There are some breaking changes in numpy version 2.0, which is now the version installed by default with 
```
pip install numpy
```

This PR attempts to address them all:

- numpy.NaN -> numpy.nan
- numpy.mat -> numpy.asmatrix
- numpy.asfarray -> numpy.asarray(..., dtype=float)