### PR TITLE
Fix bug preventing warning message from displaying correctly

### DIFF
--- a/bumps/mpfit.py
+++ b/bumps/mpfit.py
@@ -1220,7 +1220,7 @@ Keywords:
             catch_msg = 'calling '+str(fcn)
             [self.status, wa4] = self.call(fcn, self.params, functkw)
             if (self.status < 0):
-               self.errmsg = 'WARNING: premature termination by "'+fcn+'"'
+               self.errmsg = 'WARNING: premature termination by "'+str(fcn)+'"'
                return
             fnorm1 = self.enorm(wa4)
 


### PR DESCRIPTION
**Bug**
In `bumps/mpfit.py`, line 1223:

```
...
catch_msg = 'calling '+str(fcn)
[self.status, wa4] = self.call(fcn, self.params, functkw)
if (self.status < 0):
    self.errmsg = 'WARNING: premature termination by "'+fcn+'"'
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
TypeError: can only concatenate str (not "method") to str
```

**Fix**
Convert `fcn` to string:

```
...
self.errmsg = 'WARNING: premature termination by "'+str(fcn)+'"'
...
```

**Testing**
Seems to be a very simple syntax error that was probably never encountered due to being a warning message for an edge case. The corrected version seems to run as intended.
