### PR TITLE
Custom plots

### DIFF
--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -359,9 +359,9 @@ class Curve(object):
         self._plot_callbacks.update({plot_title: dict(func=plot_function,
                                                       change_with=change_with)})
 
-    def create_webview_plot(self, title, problem, state):
+    def create_webview_plot(self, title, problem, state, nshown):
 
-        return self._plot_callbacks[title]['func'](self, problem, state)
+        return self._plot_callbacks[title]['func'](self, problem, state, nshown)
 
 def _plot_resids(x, resid, colors, labels, view):
     import pylab

--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -43,6 +43,7 @@ __all__ = ["Curve", "PoissonCurve", "plot_err"]
 
 import inspect
 import warnings
+from typing import Callable
 
 import numpy as np
 from numpy import log, pi, sqrt
@@ -234,6 +235,7 @@ class Curve(object):
         self._state = state
         self._plot = plot
         self._cached_theory = None
+        self._plot_callbacks = {}
 
     def update(self):
         self._cached_theory = None
@@ -345,6 +347,19 @@ class Curve(object):
 
             pylab.subplot2grid((plot_ratio, 1), (plot_ratio-1, 0), sharex=h)
             _plot_resids(x, resid, colors=colors, labels=labels, view=view)
+
+    def register_webview_plot(self, plot_title: str, plot_function: Callable):
+        # Plot function syntax: f(model, problem, state)
+        
+        self._plot_callbacks.update({plot_title: plot_function})
+
+    def get_plot_titles(self):
+
+        return list(self._plot_callbacks.keys())
+    
+    def get_plot(self, title, problem, state):
+
+        return self._plot_callbacks[title](self, problem, state)
 
 def _plot_resids(x, resid, colors, labels, view):
     import pylab

--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -361,7 +361,7 @@ class Curve(object):
 
     def create_webview_plot(self, title, problem, state):
 
-        return self._plot_callbacks[title]['func'](deepcopy(self), problem, state)
+        return self._plot_callbacks[title]['func'](self, problem, state)
 
 def _plot_resids(x, resid, colors, labels, view):
     import pylab

--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -43,7 +43,7 @@ __all__ = ["Curve", "PoissonCurve", "plot_err"]
 
 import inspect
 import warnings
-from typing import Callable
+from typing import Callable, Literal
 
 import numpy as np
 from numpy import log, pi, sqrt
@@ -348,18 +348,19 @@ class Curve(object):
             pylab.subplot2grid((plot_ratio, 1), (plot_ratio-1, 0), sharex=h)
             _plot_resids(x, resid, colors=colors, labels=labels, view=view)
 
-    def register_webview_plot(self, plot_title: str, plot_function: Callable):
+    def register_webview_plot(self,
+                              plot_title: str,
+                              plot_function: Callable,
+                              change_with: Literal['parameter'] | Literal['uncertainty']):
         # Plot function syntax: f(model, problem, state)
+        # change_with = 'parameter' or 'uncertainty'
         
-        self._plot_callbacks.update({plot_title: plot_function})
+        self._plot_callbacks.update({plot_title: dict(func=plot_function,
+                                                      change_with=change_with)})
 
-    def get_plot_titles(self):
+    def create_webview_plot(self, title, problem, state):
 
-        return list(self._plot_callbacks.keys())
-    
-    def get_plot(self, title, problem, state):
-
-        return self._plot_callbacks[title](self, problem, state)
+        return self._plot_callbacks[title]['func'](self, problem, state)
 
 def _plot_resids(x, resid, colors, labels, view):
     import pylab

--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -44,6 +44,7 @@ __all__ = ["Curve", "PoissonCurve", "plot_err"]
 import inspect
 import warnings
 from typing import Callable, Literal
+from copy import deepcopy
 
 import numpy as np
 from numpy import log, pi, sqrt
@@ -360,7 +361,7 @@ class Curve(object):
 
     def create_webview_plot(self, title, problem, state):
 
-        return self._plot_callbacks[title]['func'](self, problem, state)
+        return self._plot_callbacks[title]['func'](deepcopy(self), problem, state)
 
 def _plot_resids(x, resid, colors, labels, view):
     import pylab

--- a/bumps/webview/client/src/components/CustomPlot.vue
+++ b/bumps/webview/client/src/components/CustomPlot.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+/// <reference types="@types/plotly.js" />
+import { ref, shallowRef, onMounted } from 'vue';
+import * as Plotly from 'plotly.js/lib/core';
+import * as mpld3 from 'mpld3';
+import { v4 as uuidv4 } from 'uuid';
+import type { AsyncSocket } from '../asyncSocket.ts';
+import { setupDrawLoop } from '../setupDrawLoop';
+import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
+
+type PlotNameInfo = {name: string, model_index: number};
+const plot_div = ref<HTMLDivElement | null>(null);
+const plot_div_id = ref(`div-${uuidv4()}`);
+const plot_title_names = ref<PlotNameInfo[]>([]);
+const current_plot_name = ref<PlotNameInfo>({"name": "", "model_index": 0});
+const current_plot_index = ref<number>(0);
+const error_text = ref<string>("")
+
+// add types to mpld3
+declare global {
+  interface mpld3 {
+    draw_figure: (div_id: string, data: { width: number, height: number }, process: boolean | Function, clearElem: boolean) => void;
+  }
+  var mpld3: mpld3;
+}
+
+const props = defineProps<{
+  socket: AsyncSocket,
+}>();
+
+async function get_custom_plot_names() {
+  const new_names = await props.socket.asyncEmit("get_custom_plot_names") as PlotNameInfo[];
+  if (new_names == null) {
+    return;
+  }
+  plot_title_names.value = new_names
+  current_plot_index.value = 0
+}
+
+props.socket.on('model_loaded', get_custom_plot_names);
+onMounted(async () => {
+  await get_custom_plot_names();
+});
+
+const { draw_requested } = setupDrawLoop('updated_parameters', props.socket, fetch_and_draw);
+
+async function fetch_and_draw() {
+  const payload = await props.socket.asyncEmit('get_custom_plot', plot_title_names.value[current_plot_index.value].model_index, plot_title_names.value[current_plot_index.value].name);
+  let { fig_type, plotdata } = payload as { fig_type: 'plotly' | 'matplotlib' | 'error', plotdata: object};
+  if (fig_type === 'plotly') {
+    error_text.value = ""
+    const { data, layout } = plotdata as Plotly.PlotlyDataLayoutConfig;
+    const config: Partial<Plotly.Config> = {
+    responsive: true,
+    edits: {
+      legendPosition: true
+    }, 
+    ...configWithSVGDownloadButton
+    }
+
+    await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
+  }
+  else if (fig_type === 'matplotlib') {
+    error_text.value = ""
+    let mpld3_data = plotdata as { width: number, height: number };
+    mpld3_data.width = Math.round(plot_div.value?.clientWidth ?? 640) - 16;
+    mpld3_data.height = Math.round(plot_div.value?.clientHeight ?? 480) - 16;
+    mpld3.draw_figure(plot_div_id.value, mpld3_data, false, true);
+  }
+  else if (fig_type === 'error') {
+    error_text.value = String(plotdata).replace(/[\n]+/g, "<br>")
+  }
+  
+}
+
+</script>
+
+<template>
+  <div class="container d-flex flex-column flex-grow-1">
+    <select
+      v-model="current_plot_index"
+      @change="draw_requested = true"
+      >
+      <option v-for="(plot_title, index) in plot_title_names" :key="index" :value="index">
+        {{ plot_title.model_index }}:  {{ plot_title.name ?? "" }} </option>
+    </select>
+    <div v-if="error_text" class="flex-grow-0" ref="error_div">
+      <div style="color:red; font-size: larger; font-weight: bold;">
+        Plotting error:
+      </div>
+      <div v-html="error_text"></div>
+    </div>    
+    <div v-if="!error_text" class="flex-grow-1" ref="plot_div" :id=plot_div_id>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.plot-mode {
+  width: 100%;
+}
+</style>

--- a/bumps/webview/client/src/components/CustomPlot.vue
+++ b/bumps/webview/client/src/components/CustomPlot.vue
@@ -8,11 +8,12 @@ import type { AsyncSocket } from '../asyncSocket.ts';
 import { setupDrawLoop } from '../setupDrawLoop';
 import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
 
-type PlotNameInfo = {name: string, model_index: number};
+type PlotNameInfo = {name: string, change_with: string, model_index: number};
+const title = 'Custom'
 const plot_div = ref<HTMLDivElement | null>(null);
 const plot_div_id = ref(`div-${uuidv4()}`);
 const plot_title_names = ref<PlotNameInfo[]>([]);
-const current_plot_name = ref<PlotNameInfo>({"name": "", "model_index": 0});
+//const current_plot_name = ref<PlotNameInfo>({"name": "", "change_with": "parameters", "model_index": 0});
 const current_plot_index = ref<number>(0);
 const error_text = ref<string>("")
 
@@ -33,7 +34,7 @@ async function get_custom_plot_names() {
   if (new_names == null) {
     return;
   }
-  plot_title_names.value = new_names
+  plot_title_names.value = new_names.filter(a => a.change_with === 'parameter')
   current_plot_index.value = 0
 }
 

--- a/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
+++ b/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+/// <reference types="@types/plotly.js" />
+import { ref, shallowRef, onMounted } from 'vue';
+import * as Plotly from 'plotly.js/lib/core';
+import * as mpld3 from 'mpld3';
+import { v4 as uuidv4 } from 'uuid';
+import type { AsyncSocket } from '../asyncSocket.ts';
+import { setupDrawLoop } from '../setupDrawLoop';
+import { cache } from '../plotcache';
+import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
+
+type PlotNameInfo = {name: string, change_with: string, model_index: number};
+const title = "Custom Uncertainty"
+const plot_div = ref<HTMLDivElement | null>(null);
+const plot_div_id = ref(`div-${uuidv4()}`);
+const plot_title_names = ref<PlotNameInfo[]>([]);
+//const current_plot_name = ref<PlotNameInfo>({"name": "", "change_with": "uncertainty", "model_index": 0});
+const current_plot_index = ref<number>(0);
+const error_text = ref<string>("")
+
+// add types to mpld3
+declare global {
+  interface mpld3 {
+    draw_figure: (div_id: string, data: { width: number, height: number }, process: boolean | Function, clearElem: boolean) => void;
+  }
+  var mpld3: mpld3;
+}
+
+const props = defineProps<{
+  socket: AsyncSocket,
+}>();
+
+async function get_custom_plot_names() {
+  const new_names = await props.socket.asyncEmit("get_custom_plot_names") as PlotNameInfo[];
+  if (new_names == null) {
+    return;
+  }
+  plot_title_names.value = new_names.filter(a => a.change_with === "uncertainty")
+  current_plot_index.value = 0
+}
+
+props.socket.on('model_loaded', get_custom_plot_names);
+onMounted(async () => {
+  await get_custom_plot_names();
+});
+
+const { draw_requested, drawing_busy } = setupDrawLoop('updated_uncertainty', props.socket, fetch_and_draw, title);
+
+async function fetch_and_draw(latest_timestamp: string) {
+
+    let cache_key = title + plot_title_names.value[current_plot_index.value].model_index + plot_title_names.value[current_plot_index.value].name
+    let read_cache = cache[cache_key] as { timestamp: string, plotdata: object } ?? {};
+    let timestamp = read_cache.timestamp
+    let payload = read_cache.plotdata
+    //console.log([timestamp, latest_timestamp])
+    if (timestamp !== latest_timestamp) {
+        console.log("fetching new model uncertainty plot", timestamp, latest_timestamp);
+
+        payload = await props.socket.asyncEmit('get_custom_plot', plot_title_names.value[current_plot_index.value].model_index, plot_title_names.value[current_plot_index.value].name);
+        cache[cache_key] = {timestamp: latest_timestamp, plotdata: payload};    
+    }
+    //console.log(payload)
+    let { fig_type, plotdata } = payload as { fig_type: 'plotly' | 'matplotlib' | 'error', plotdata: object};
+    if (fig_type === 'plotly') {
+        error_text.value = ""
+        const { data, layout } = plotdata as Plotly.PlotlyDataLayoutConfig;
+        const config: Partial<Plotly.Config> = {
+        responsive: true,
+        edits: {
+        legendPosition: true
+        }, 
+        ...configWithSVGDownloadButton
+        }
+
+        await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
+    }
+    else if (fig_type === 'matplotlib') {
+        error_text.value = ""
+        let mpld3_data = plotdata as { width: number, height: number };
+        mpld3_data.width = Math.round(plot_div.value?.clientWidth ?? 640) - 16;
+        mpld3_data.height = Math.round(plot_div.value?.clientHeight ?? 480) - 16;
+        mpld3.draw_figure(plot_div_id.value, mpld3_data, false, true);
+    }
+    else if (fig_type === 'error') {
+        error_text.value = String(plotdata).replace(/[\n]+/g, "<br>")
+    }
+}
+
+</script>
+
+<template>
+  <div class="container d-flex flex-column flex-grow-1">
+    <select
+      v-model="current_plot_index"
+      @change="draw_requested = true"
+      >
+      <option v-for="(plot_title, index) in plot_title_names" :key="index" :value="index">
+        {{ plot_title.model_index }}:  {{ plot_title.name ?? "" }} </option>
+    </select>
+    <div v-if="error_text" class="flex-grow-0" ref="error_div">
+      <div style="color:red; font-size: larger; font-weight: bold;">
+        Plotting error:
+      </div>
+      <div v-html="error_text"></div>
+    </div>
+    <div v-if="!error_text" class="flex-grow-1 position-relative">
+      <div class="w-100 h-100 plot-div" ref="plot_div" :id=plot_div_id></div>
+      <div class="position-absolute top-0 start-0 w-100 h-100 d-flex flex-column align-items-center justify-content-center loading" v-if="drawing_busy">
+        <span class="spinner-border text-primary"></span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+svg {
+  width: 100%;
+}
+span.spinner-border {
+  width: 3rem;
+  height: 3rem;
+}
+</style>

--- a/bumps/webview/client/src/panels.mjs
+++ b/bumps/webview/client/src/panels.mjs
@@ -10,6 +10,7 @@ import ModelUncertaintyView from './components/ModelUncertaintyView.vue';
 import UncertaintyView from './components/UncertaintyView.vue';
 import CustomPlot from './components/CustomPlot.vue';
 import History from './components/History.vue';
+import CustomUncertaintyPlot from './components/CustomUncertaintyPlot.vue';
 
 export const panels = [
     {title: 'Data', component: DataView},
@@ -23,6 +24,7 @@ export const panels = [
     {title: 'Trace', component: ParameterTraceView},
     {title: 'Model Uncertainty', component: ModelUncertaintyView},
     {title: 'Uncertainty', component: UncertaintyView},
-    {title: 'Custom', component: CustomPlot}
+    {title: 'Custom', component: CustomPlot},
+    {title: 'Custom Uncertainty', component: CustomUncertaintyPlot}
   ];
   

--- a/bumps/webview/client/src/panels.mjs
+++ b/bumps/webview/client/src/panels.mjs
@@ -8,6 +8,7 @@ import CorrelationView from './components/CorrelationViewPlotly.vue';
 import ParameterTraceView from './components/ParameterTraceView.vue';
 import ModelUncertaintyView from './components/ModelUncertaintyView.vue';
 import UncertaintyView from './components/UncertaintyView.vue';
+import CustomPlot from './components/CustomPlot.vue';
 import History from './components/History.vue';
 
 export const panels = [
@@ -22,5 +23,6 @@ export const panels = [
     {title: 'Trace', component: ParameterTraceView},
     {title: 'Model Uncertainty', component: ModelUncertaintyView},
     {title: 'Uncertainty', component: UncertaintyView},
+    {title: 'Custom', component: CustomPlot}
   ];
   

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -570,7 +570,7 @@ async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebview
     if state.problem is None or state.problem.fitProblem is None:
         return None
     fitProblem = deepcopy(state.problem.fitProblem)
-    uncertainty_state = deepcopy(state.fitting.uncertainty_state)
+    uncertainty_state = state.fitting.uncertainty_state
 
     # update model
     model = list(fitProblem.models)[model_index]

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -565,7 +565,7 @@ async def get_custom_plot_names():
                    for title, plotinfo in model._plot_callbacks.items()]
     return output
 
-async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebviewPlot:
+async def create_custom_plot(model_index: int, plot_title: str, nshown: int) -> CustomWebviewPlot:
 
     if state.problem is None or state.problem.fitProblem is None:
         return None
@@ -578,7 +578,7 @@ async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebview
         try:
             model.update()
             model.nllf()
-            plot_item: CustomWebviewPlot = await asyncio.to_thread(model.create_webview_plot, plot_title, fitProblem, uncertainty_state)
+            plot_item: CustomWebviewPlot = await asyncio.to_thread(model.create_webview_plot, plot_title, fitProblem, uncertainty_state, nshown)
         except:
             plot_item = CustomWebviewPlot(fig_type='error',
                                           plotdata=traceback.format_exc())
@@ -588,10 +588,10 @@ async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebview
     return {}
    
 @register
-async def get_custom_plot(model_index: int, plot_title: str):
+async def get_custom_plot(model_index: int, plot_title: str, nshown: int = 1):
     output = CustomWebviewPlot(figtype='error', plotdata='no plot')
     if model_index is not None:
-        figdict = await create_custom_plot(model_index=model_index, plot_title=plot_title)
+        figdict = await create_custom_plot(model_index=model_index, plot_title=plot_title, nshown=nshown)
         
     output = to_json_compatible_dict(figdict)
     return output

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -570,7 +570,7 @@ async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebview
     if state.problem is None or state.problem.fitProblem is None:
         return None
     fitProblem = deepcopy(state.problem.fitProblem)
-    uncertainty_state = state.fitting.uncertainty_state
+    uncertainty_state = deepcopy(state.fitting.uncertainty_state)
 
     # update model
     model = list(fitProblem.models)[model_index]

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -557,11 +557,12 @@ async def get_custom_plot_names():
     if state.problem is None or state.problem.fitProblem is None:
         return None
     fitProblem = state.problem.fitProblem
-    output: List[Dict[int, str]] = []
+    output: List[dict] = []
     for model_index, model in enumerate(fitProblem.models):
         output += [dict(model_index=model_index,
+                        change_with=plotinfo['change_with'],
                         name=title)
-                        for title in model.get_plot_titles()]
+                   for title, plotinfo in model._plot_callbacks.items()]
     return output
 
 async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebviewPlot:
@@ -573,11 +574,11 @@ async def create_custom_plot(model_index: int, plot_title: str) -> CustomWebview
 
     # update model
     model = list(fitProblem.models)[model_index]
-    if plot_title in model.get_plot_titles():
+    if plot_title in model._plot_callbacks.keys():
         try:
             model.update()
             model.nllf()
-            plot_item: CustomWebviewPlot = model.get_plot(plot_title, fitProblem, uncertainty_state)
+            plot_item: CustomWebviewPlot = await asyncio.to_thread(model.create_webview_plot, plot_title, fitProblem, uncertainty_state)
         except:
             plot_item = CustomWebviewPlot(fig_type='error',
                                           plotdata=traceback.format_exc())

--- a/bumps/webview/server/custom_plot.py
+++ b/bumps/webview/server/custom_plot.py
@@ -21,5 +21,6 @@ def process_custom_plot(plot_item: CustomWebviewPlot) -> CustomWebviewPlot:
     
     del plot_data # is this necessary? Does plot_item['plot_data'] also need to be deleted?
     
-    return CustomWebviewPlot(fig_type=figtype, plotdata=figdict)
+    return CustomWebviewPlot(fig_type=figtype,
+                             plotdata=figdict)
 

--- a/bumps/webview/server/custom_plot.py
+++ b/bumps/webview/server/custom_plot.py
@@ -1,0 +1,25 @@
+from typing import Literal, TypedDict, Any
+
+class CustomWebviewPlot(TypedDict):
+    fig_type: Literal['plotly'] | Literal ['matplotlib'] | Literal['error'] = 'plotly'
+    plotdata: Any
+
+def process_custom_plot(plot_item: CustomWebviewPlot) -> CustomWebviewPlot:
+    
+    figtype = plot_item['fig_type']
+    plot_data = plot_item['plotdata']
+
+    if figtype == 'plotly':
+        figdict = plot_data.to_dict()
+    elif figtype == 'matplotlib':
+        import mpld3
+        figdict = mpld3.fig_to_dict(plot_data)
+    elif figtype == 'error':
+        figdict = plot_data
+    else:
+        figdict = dict(error=f'unrecognized plot type {figtype}')
+    
+    del plot_data # is this necessary? Does plot_item['plot_data'] also need to be deleted?
+    
+    return CustomWebviewPlot(fig_type=figtype, plotdata=figdict)
+


### PR DESCRIPTION
Adds custom plotting hooks to `Fitness`-type objects (in this case, `bumps.Curve` to be extended to `refl1d.ExperimentBase`).

Custom plotting functions are defined by registering them to a model with a descriptive string using `register_webview_plot`.

When the plot is requested, a copy of the model is refreshed (with `.update()` and `.nllf()`, and the arguments `model`, `problem`, and `state` passed through. The function returns a `CustomWebviewPlot(TypedDict)` object with fields `fig_type` and `plotdata`, following the current naming conventions.

Currently `plotly`, `matplotlib`, and `error` are allowed types; `error` displays the traceback of the plotting function to enable real-time debugging.

Subclasses of `Fitness`-type objects can automatically register any plotting functions intrinsic to that class, allowing the registration process to be compatible with serialization of these classes.