### PR TITLE
catch error returned on first run of lmfit (TypeError)

### DIFF
--- a/bumps/gui/convergence_view.py
+++ b/bumps/gui/convergence_view.py
@@ -24,7 +24,7 @@ class ConvergenceMonitor(monitor.Monitor):
             p = np.sort(pop)
             QI,Qmid, = int(0.2*n),int(0.5*n)
             self.pop.append((best, p[0],p[QI],p[Qmid],p[-1-QI],p[-1]))
-        except AttributeError:
+        except (AttributeError, TypeError):
             self.pop.append((best, ))
     def progress(self):
         if not self.pop:

--- a/bumps/webview/server/fit_thread.py
+++ b/bumps/webview/server/fit_thread.py
@@ -93,7 +93,7 @@ class ConvergenceMonitor(monitor.Monitor):
             p = np.sort(pop)
             QI,Qmid, = int(0.2*n),int(0.5*n)
             self.pop.append((best, p[0],p[QI],p[Qmid],p[-1-QI],p[-1]))
-        except AttributeError:
+        except (AttributeError, TypeError):
             self.pop.append((best, ))
 
         if self.rate > 0 and history.time[0] >= self.time+self.rate:


### PR DESCRIPTION
This might not be the right way to handle this, but it seems that `history.population_values == [None]` so that `pop is None` the first time `ConvergenceMonitor.__call__` is invoked during an `lmfit` fit session.  This causes the expression `len(pop)` on line 92 of `bumps/webview/server/fit_thread.py` (and also in `bumps/gui/convergence_view.py`) to throw a TypeError exception.

One way to handle it is to catch the TypeError.  Another would be to alter the guard statement to check if `pop` would be `None`.

Probably worth looking over to make sure we're really fixing the error (it seems weird that for that fitter `history.population_values == [None]` on the first call, when that doesn't happen for other fitters)
