### PR TITLE
Trace plot update

### DIFF
--- a/bumps/webview/client/src/components/ParameterTraceView.vue
+++ b/bumps/webview/client/src/components/ParameterTraceView.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 /// <reference types="@types/uuid"/>
-import { ref, onMounted } from 'vue';
+import { ref, shallowRef, onMounted } from 'vue';
 import { Socket } from 'socket.io-client';
 import { v4 as uuidv4 } from 'uuid';
 import { setupDrawLoop } from '../setupDrawLoop';
 import * as Plotly from 'plotly.js/lib/core';
 import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
 
+const plot_data = shallowRef<Plotly.Data[]>([]);
+const plot_layout = shallowRef<Partial<Plotly.Layout>>();
+const plot_config = shallowRef<Partial<Plotly.Config>>();
 const plot_div = ref<HTMLDivElement>();
 const plot_div_id = ref(`div-${uuidv4()}`);
 const current_index = ref<number>(0);
 const parameters_local = ref<String[]>([]);
+const trace_opacity = ref(0.4);
 const props = defineProps<{
   socket: Socket,
 }>();
@@ -37,14 +41,31 @@ onMounted(async () => {
 async function fetch_and_draw() {
 
   const payload = await props.socket.asyncEmit('get_parameter_trace_plot', current_index.value) as Plotly.PlotlyDataLayoutConfig;
+
   let plotdata = { ...payload };
   const { data, layout } = plotdata;
+  plot_data.value = data
+  plot_layout.value = layout
   const config: Partial<Plotly.Config> = {
     responsive: true,
     ...configWithSVGDownloadButton
   }
 
-  await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
+  plot_config.value = config
+
+  plot_data.value = data
+
+  await draw_plot()
+
+}
+
+async function draw_plot() {
+  const opacity = trace_opacity.value
+
+  let data = plot_data.value
+  data.forEach(line => line.opacity = opacity)
+  
+  await Plotly.react(plot_div.value as HTMLDivElement, [...data], plot_layout.value, plot_config.value);
 
 }
 
@@ -59,6 +80,14 @@ async function fetch_and_draw() {
       <option v-for="(parameter, index) in parameters_local" :key="index" :value="index">
         {{ parameter ?? "" }} </option>
     </select>
+    <div class="row px-2 align-items-center">
+      <div class="col-auto">
+        <label for="opacity_control" class="col-form-label">Trace opacity</label>
+      </div>
+      <div class="col">
+        <input type="range" min="0" max="1.0" step="0.01" id="opacity_control" class="form-range" v-model.number="trace_opacity" @input="draw_plot">
+      </div>
+    </div>
     <div class="flex-grow-1" ref="plot_div" :id="plot_div_id">
     </div>
   </div>

--- a/bumps/webview/client/src/components/ParameterTraceView.vue
+++ b/bumps/webview/client/src/components/ParameterTraceView.vue
@@ -1,36 +1,64 @@
 <script setup lang="ts">
 /// <reference types="@types/uuid"/>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { Socket } from 'socket.io-client';
 import { v4 as uuidv4 } from 'uuid';
 import { setupDrawLoop } from '../setupDrawLoop';
-import * as mpld3 from 'mpld3';
+import * as Plotly from 'plotly.js/lib/core';
+import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
 
 const plot_div = ref<HTMLDivElement>();
 const plot_div_id = ref(`div-${uuidv4()}`);
+const current_index = ref<number>(0);
+const parameters_local = ref<String[]>([]);
 const props = defineProps<{
   socket: Socket,
 }>();
 
-setupDrawLoop('updated_uncertainty', props.socket, fetch_and_draw);
+const { draw_requested } = setupDrawLoop('updated_uncertainty', props.socket, fetch_and_draw);
 
-type MplD3PlotData = {
-  width?: number,
-  height?: number,
+async function get_parameter_names() {
+  const new_pars = await props.socket.asyncEmit("get_parameter_labels") as String[];
+  if (new_pars == null) {
+    return;
+  }
+  if (current_index.value > parameters_local.value.length) {
+    current_index.value = 0
+  }
+  parameters_local.value = new_pars
 }
 
+props.socket.on('model_loaded', get_parameter_names);
+
+onMounted(async () => {
+  await get_parameter_names();
+});
+
 async function fetch_and_draw() {
-  const payload = await props.socket.asyncEmit('get_parameter_trace_plot') as MplD3PlotData;
+
+  const payload = await props.socket.asyncEmit('get_parameter_trace_plot', current_index.value) as Plotly.PlotlyDataLayoutConfig;
   let plotdata = { ...payload };
-  plotdata.width = Math.round(plot_div.value?.clientWidth ?? 640) - 16;
-  plotdata.height = Math.round(plot_div.value?.clientHeight ?? 480) - 16;
-  mpld3.draw_figure(plot_div_id.value, plotdata, false, true);
+  const { data, layout } = plotdata;
+  const config: Partial<Plotly.Config> = {
+    responsive: true,
+    ...configWithSVGDownloadButton
+  }
+
+  await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
+
 }
 
 </script>
     
 <template>
   <div class="container d-flex flex-grow-1 flex-column">
+    <select
+      v-model="current_index"
+      @change="draw_requested = true"
+      >
+      <option v-for="(parameter, index) in parameters_local" :key="index" :value="index">
+        {{ parameter ?? "" }} </option>
+    </select>
     <div class="flex-grow-1" ref="plot_div" :id="plot_div_id">
     </div>
   </div>

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -758,17 +758,12 @@ async def get_parameter_labels():
 
     if state.problem is None or state.problem.fitProblem is None:
         return None
-    fitProblem = state.problem.fitProblem
-    if fitProblem is not None:
-        return to_json_compatible_dict(fitProblem.labels())
-    else:
-        return None
+    return to_json_compatible_dict(state.problem.fitProblem.labels())
 
 @register
 async def get_parameter_trace_plot(var: int):
     
     uncertainty_state = state.fitting.uncertainty_state
-    logger.info(f'Got parameter_trace plot request with index {var}')
     if uncertainty_state is not None:
         import time
 
@@ -782,7 +777,7 @@ async def get_parameter_trace_plot(var: int):
         start = int((1-portion)*len(draw)) if portion else 0
         genid = np.arange(uncertainty_state.generation-len(draw)+start, uncertainty_state.generation)+1
         fig = plot_trace(genid*uncertainty_state.thinning,
-             np.squeeze(points[start:, uncertainty_state._good_chains, var]).T, label=label, alpha=0.2)
+             np.squeeze(points[start:, uncertainty_state._good_chains, var]).T, label=label, alpha=0.4)
 
         logger.info(f"time to render but not serialize... {time.time() - start_time}")
         dfig = fig.to_dict()

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -26,6 +26,7 @@ import bumps.errplot
 from .state_hdf5_backed import UNDEFINED, UNDEFINED_TYPE, State, serialize_problem, deserialize_problem, SERIALIZER_EXTENSIONS
 from .fit_thread import FitThread, EVT_FIT_COMPLETE, EVT_FIT_PROGRESS
 from .varplot import plot_vars
+from .traceplot import plot_trace
 from .logger import logger, console_handler
 from .custom_plot import process_custom_plot, CustomWebviewPlot
 
@@ -748,40 +749,46 @@ async def get_model_uncertainty_plot():
         return None
 
 @register
-async def get_parameter_trace_plot():
+async def get_parameter_labels():
+    # Required to support get_parameter_trace_plot because ordering must be preserved.
+    # There is no way to know whether a disambiguated name occurred first or second from
+    # get_parameters. Uses fitProblem because uncertainty state might not exist and
+    # list of parameters should be updated on model_loaded.
+    # Should probably be able to call these parameters by ID.
+
+    if state.problem is None or state.problem.fitProblem is None:
+        return None
+    fitProblem = state.problem.fitProblem
+    if fitProblem is not None:
+        return to_json_compatible_dict(fitProblem.labels())
+    else:
+        return None
+
+@register
+async def get_parameter_trace_plot(var: int):
+    
     uncertainty_state = state.fitting.uncertainty_state
+    logger.info(f'Got parameter_trace plot request with index {var}')
     if uncertainty_state is not None:
-        import mpld3
-        import matplotlib
-        matplotlib.use("agg")
-        import matplotlib.pyplot as plt
         import time
 
         start_time = time.time()
         logger.info(f'queueing new parameter_trace plot... {start_time}')
 
-        fig = plt.figure()
-        axes = fig.add_subplot(111)
-
         # begin plotting:
-        var = 0
         portion = None
         draw, points, _ = uncertainty_state.chains()
         label = uncertainty_state.labels[var]
         start = int((1-portion)*len(draw)) if portion else 0
         genid = np.arange(uncertainty_state.generation-len(draw)+start, uncertainty_state.generation)+1
-        axes.plot(genid*uncertainty_state.thinning,
-             np.squeeze(points[start:, uncertainty_state._good_chains, var]))
-        axes.set_xlabel('Generation number')
-        axes.set_ylabel(label)
-        fig.canvas.draw()
+        fig = plot_trace(genid*uncertainty_state.thinning,
+             np.squeeze(points[start:, uncertainty_state._good_chains, var]).T, label=label, alpha=0.2)
 
         logger.info(f"time to render but not serialize... {time.time() - start_time}")
-        dfig = mpld3.fig_to_dict(fig)
-        plt.close(fig)
+        dfig = fig.to_dict()
         end_time = time.time()
         logger.info(f"time to draw parameter_trace plot: {end_time - start_time}")
-        return dfig
+        return to_json_compatible_dict(dfig)
     else:
         return None
     

--- a/bumps/webview/server/colors.py
+++ b/bumps/webview/server/colors.py
@@ -1,0 +1,2 @@
+# Colorblind-friendly colors, as per https://gist.github.com/thriveth/8560036
+COLORS = ["#377eb8", "#ff7f00", "#4daf4a", "#f781bf", "#a65628", "#984ea3", "#999999", "#e41a1c", "#dede00"]

--- a/bumps/webview/server/traceplot.py
+++ b/bumps/webview/server/traceplot.py
@@ -5,18 +5,23 @@ Build trace plots (plotly)
 __all__ = ['plot_trace']
 
 import numpy as np
+from .colors import COLORS
 
 def plot_trace(x: list | np.ndarray, ys: list | np.ndarray, label='', alpha=0.4):
 
     import plotly.graph_objs as go
 
     traces = []
+    color_idx = 0
     for y in ys:
+        color = COLORS[color_idx % len(COLORS)]
         traces.append(go.Scatter(x=x,
                                 y=y,
                                 mode='lines',
                                 showlegend=False,
+                                line=dict(color=color),
                                 opacity=alpha))
+        color_idx += 1
 
     fig = go.Figure(data=traces)
 

--- a/bumps/webview/server/traceplot.py
+++ b/bumps/webview/server/traceplot.py
@@ -1,0 +1,31 @@
+"""
+Build trace plots (plotly)
+"""
+
+__all__ = ['plot_trace']
+
+import numpy as np
+
+def plot_trace(x: list | np.ndarray, ys: list | np.ndarray, label='', alpha=0.4):
+
+    import plotly.graph_objs as go
+
+    traces = []
+    for y in ys:
+        traces.append(go.Scatter(x=x,
+                                y=y,
+                                mode='lines',
+                                showlegend=False,
+                                opacity=alpha))
+
+    fig = go.Figure(data=traces)
+
+    fig.update_layout(
+        template = 'plotly_white',
+        xaxis_title=dict(text='Generation number'),
+        yaxis_title=dict(text=label),
+        yaxis=dict(exponentformat='e'),
+        showlegend=False
+    )
+
+    return fig

--- a/bumps/webview/server/traceplot.py
+++ b/bumps/webview/server/traceplot.py
@@ -2,12 +2,15 @@
 Build trace plots (plotly)
 """
 
+from typing import Union
+
 __all__ = ['plot_trace']
 
 import numpy as np
 from .colors import COLORS
 
-def plot_trace(x: list | np.ndarray, ys: list | np.ndarray, label='', alpha=0.4):
+# TODO: when minimum python version is 3.10, can use | to combine types 
+def plot_trace(x: Union[list, np.ndarray], ys: Union[list, np.ndarray], label='', alpha=0.4):
 
     import plotly.graph_objs as go
 


### PR DESCRIPTION
Fresh version of https://github.com/bumps/bumps/pull/168

Update to the parameter trace plot. Major changes:

1. Plot is now rendered in plotly
2. Any fittable parameter can be selected for inspection.
3. Colors has been moved from refl1d to bumps

An open question:
At the moment the parameter trace plot is using uncertainty_state, and it updates with the "updated_uncertainty" signal. It is not clear to me if the information in this plot can be updated more regularly; a more natural update signal would be "updated_convergence", but of course at the moment the uncertainty state isn't updated with the convergence updates so this doesn't really make sense.