### PR TITLE
Custom plot table

### DIFF
--- a/bumps/webview/client/src/components/CSVTable.vue
+++ b/bumps/webview/client/src/components/CSVTable.vue
@@ -29,14 +29,14 @@ async function download_csv() {
         </div>
         <table class="table">
             <thead class="border-bottom py-1 sticky-top text-white bg-secondary">
-            <tr>
-                <th v-for="header_item in table_data.header" scope="col">{{ header_item }}</th>
-            </tr>
+                <tr>
+                    <th v-for="header_item in table_data.header" scope="col">{{ header_item }}</th>
+                </tr>
             </thead>
             <tbody>
-            <tr class="py-1" v-for="table_row in table_data.rows">
-                <td v-for="table_item in table_row" scope="col">{{ table_item }}</td>
-            </tr>
+                <tr class="py-1" v-for="table_row in table_data.rows">
+                    <td v-for="table_item in table_row" scope="col">{{ table_item }}</td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/bumps/webview/client/src/components/CSVTable.vue
+++ b/bumps/webview/client/src/components/CSVTable.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+export type TableData = {
+    raw: string,
+    header: string[],
+    rows: string[][]
+}
+
+const hidden_download = ref<HTMLAnchorElement>();
+
+const props = defineProps<{table_data: TableData}>();
+
+async function download_csv() {
+  if (props.table_data.raw) {
+    const a = hidden_download.value as HTMLAnchorElement;
+    a.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(props.table_data.raw);
+    a.click();
+  }
+}
+
+</script>
+
+<template>
+    <div class="flex-grow-0" ref="table_div">
+        <div>
+            <button class="btn btn-primary btn-sm" @click="download_csv">Download CSV</button>
+            <a ref="hidden_download" class="hidden" download='table.csv' type='text/csv'>Download CSV</a>
+        </div>
+        <table class="table">
+            <thead class="border-bottom py-1 sticky-top text-white bg-secondary">
+            <tr>
+                <th v-for="header_item in table_data.header" scope="col">{{ header_item }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr class="py-1" v-for="table_row in table_data.rows">
+                <td v-for="table_item in table_row" scope="col">{{ table_item }}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+  </template>
+
+<style scoped>
+.hidden {
+  display: none;
+}
+</style>

--- a/bumps/webview/client/src/components/CustomPlot.vue
+++ b/bumps/webview/client/src/components/CustomPlot.vue
@@ -7,15 +7,19 @@ import { v4 as uuidv4 } from 'uuid';
 import type { AsyncSocket } from '../asyncSocket.ts';
 import { setupDrawLoop } from '../setupDrawLoop';
 import { configWithSVGDownloadButton } from '../plotly_extras.mjs';
+import { TableData} from './CSVTable.vue'
+import CSVTable from './CSVTable.vue'
 
 type PlotInfo = {title: string, change_with: string, model_index: number};
 const title = 'Custom'
+const figtype = ref<String>("")
 const plot_div = ref<HTMLDivElement | null>(null);
 const plot_div_id = ref(`div-${uuidv4()}`);
 const plot_infos = ref<PlotInfo[]>([]);
 //const current_plot_name = ref<PlotNameInfo>({"name": "", "change_with": "parameters", "model_index": 0});
 const current_plot_index = ref<number>(0);
 const error_text = ref<string>("")
+const table_data = ref<TableData>({raw: "", header: [], rows: [[]]})
 
 // add types to mpld3
 declare global {
@@ -48,9 +52,9 @@ const { draw_requested } = setupDrawLoop('updated_parameters', props.socket, fet
 async function fetch_and_draw() {
   const { model_index, title } = plot_infos.value[current_plot_index.value];
   const payload = await props.socket.asyncEmit('get_custom_plot', model_index, title);
-  let { fig_type, plotdata } = payload as { fig_type: 'plotly' | 'matplotlib' | 'error', plotdata: object};
+  const { fig_type, plotdata } = payload as { fig_type: 'plotly' | 'matplotlib' | 'table' | 'error', plotdata: object};
+  figtype.value = fig_type
   if (fig_type === 'plotly') {
-    error_text.value = "";
     await nextTick();
     const { data, layout } = plotdata as Plotly.PlotlyDataLayoutConfig;
     const config: Partial<Plotly.Config> = {
@@ -64,17 +68,23 @@ async function fetch_and_draw() {
     await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
   }
   else if (fig_type === 'matplotlib') {
-    error_text.value = ""
     await nextTick();
     let mpld3_data = plotdata as { width: number, height: number };
     mpld3_data.width = Math.round(plot_div.value?.clientWidth ?? 640) - 16;
     mpld3_data.height = Math.round(plot_div.value?.clientHeight ?? 480) - 16;
     mpld3.draw_figure(plot_div_id.value, mpld3_data, false, true);
   }
+  else if (fig_type === 'table') {
+    await nextTick();
+    table_data.value = plotdata as TableData;
+  }  
   else if (fig_type === 'error') {
     error_text.value = String(plotdata).replace(/[\n]+/g, "<br>");
   }
-  
+  else {
+    figtype.value = 'error';
+    error_text.value = "Unknown figure type " + fig_type;
+  }  
 }
 
 </script>
@@ -88,12 +98,15 @@ async function fetch_and_draw() {
       <option v-for="(plot_info, index) in plot_infos" :key="index" :value="index">
         {{ plot_info.model_index }}:  {{ plot_info.title ?? "" }} </option>
     </select>
-    <div v-if="error_text" class="flex-grow-0" ref="error_div">
+    <div v-if="figtype==='error'" class="flex-grow-0" ref="error_div">
       <div style="color:red; font-size: larger; font-weight: bold;">
         Plotting error:
       </div>
       <div v-html="error_text"></div>
-    </div>    
+    </div>
+    <div v-else-if="figtype==='table'" class="flex-grow-0">
+      <CSVTable :table_data="table_data"></CSVTable>
+    </div>
     <div v-else class="flex-grow-1" ref="plot_div" :id=plot_div_id>
     </div>
   </div>

--- a/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
+++ b/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
@@ -126,7 +126,7 @@ async function fetch_and_draw(latest_timestamp?: string) {
       </div>
       <div v-html="error_text"></div>
     </div>
-    <div v-else-if="figtype==='table'" class="flex-grow-0" ref="table_div">
+    <div v-else-if="figtype==='table'" class="flex-grow-0">
       <CSVTable :table_data="table_data"></CSVTable>
     </div>
     <div v-else class="flex-grow-1 position-relative">

--- a/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
+++ b/bumps/webview/client/src/components/CustomUncertaintyPlot.vue
@@ -120,7 +120,7 @@ async function fetch_and_draw(latest_timestamp?: string) {
         <input class="form-control" type="number" v-model="n_samples" id="n_samples" @change="draw_requested = true" />
       </div>
     </div>      
-    <div v-if="figtype=='error'" class="flex-grow-0" ref="error_div">
+    <div v-if="figtype==='error'" class="flex-grow-0" ref="error_div">
       <div style="color:red; font-size: larger; font-weight: bold;">
         Plotting error:
       </div>

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -27,7 +27,7 @@ from .state_hdf5_backed import UNDEFINED, UNDEFINED_TYPE, State, serialize_probl
 from .fit_thread import FitThread, EVT_FIT_COMPLETE, EVT_FIT_PROGRESS
 from .varplot import plot_vars
 from .logger import logger, console_handler
-from .custom_plot import process_custom_plot, CustomWebviewPlot
+from .custom_plot import process_custom_plot, CustomWebviewPlot, dict2csv
 
 REGISTRY: Dict[str, Callable] = {}
 MODEL_EXT = '.json'
@@ -636,6 +636,10 @@ async def get_custom_plot(model_index: int, plot_title: str, n_samples: int = 1)
         
     output = to_json_compatible_dict(figdict)
     return output
+
+@register
+async def get_csv_from_table(table_data: dict):
+    return to_json_compatible_dict(dict2csv(table_data))
 
 @register
 async def get_convergence_plot():

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -27,7 +27,7 @@ from .state_hdf5_backed import UNDEFINED, UNDEFINED_TYPE, State, serialize_probl
 from .fit_thread import FitThread, EVT_FIT_COMPLETE, EVT_FIT_PROGRESS
 from .varplot import plot_vars
 from .logger import logger, console_handler
-from .custom_plot import process_custom_plot, CustomWebviewPlot, dict2csv
+from .custom_plot import process_custom_plot, CustomWebviewPlot
 
 REGISTRY: Dict[str, Callable] = {}
 MODEL_EXT = '.json'

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -638,10 +638,6 @@ async def get_custom_plot(model_index: int, plot_title: str, n_samples: int = 1)
     return output
 
 @register
-async def get_csv_from_table(table_data: dict):
-    return to_json_compatible_dict(dict2csv(table_data))
-
-@register
 async def get_convergence_plot():
     if state.problem is None or state.problem.fitProblem is None:
         return None

--- a/bumps/webview/server/custom_plot.py
+++ b/bumps/webview/server/custom_plot.py
@@ -1,7 +1,25 @@
+import io
+import csv
 from typing import Literal, TypedDict, Any
 
+def csv2dict(csvdata: str) -> dict:
+    with io.StringIO(csvdata) as f:
+        reader = csv.DictReader(f)
+        result=dict(header=reader.fieldnames,
+                    rows=[row for row in reader])    
+    
+    return result
+
+def dict2csv(csvdict: dict) -> str:
+    with io.StringIO() as f:
+        writer = csv.DictWriter(f, fieldnames=csvdict['header'])
+        writer.writerows(csvdict['rows'])
+        result = f.getvalue()
+
+    return result
+
 class CustomWebviewPlot(TypedDict):
-    fig_type: Literal['plotly', 'matplotlib', 'error'] = 'plotly'
+    fig_type: Literal['plotly', 'matplotlib', 'table', 'error'] = 'plotly'
     plotdata: Any
 
 def process_custom_plot(plot_item: CustomWebviewPlot) -> CustomWebviewPlot:
@@ -14,6 +32,8 @@ def process_custom_plot(plot_item: CustomWebviewPlot) -> CustomWebviewPlot:
     elif figtype == 'matplotlib':
         import mpld3
         figdict = mpld3.fig_to_dict(plot_data)
+    elif figtype == 'table':
+        figdict = csv2dict(plot_data)
     elif figtype == 'error':
         figdict = plot_data
     else:

--- a/bumps/webview/server/custom_plot.py
+++ b/bumps/webview/server/custom_plot.py
@@ -6,11 +6,14 @@ def csv2dict(csvdata: str) -> dict:
     with io.StringIO(csvdata) as f:
         reader = csv.DictReader(f)
         result=dict(header=reader.fieldnames,
-                    rows=[row for row in reader])    
+                    rows=[row for row in reader],
+                    raw=csvdata)    
     
     return result
 
 def dict2csv(csvdict: dict) -> str:
+    # No longer needed since raw csv data are added to the table data
+    # dictionary in csv2dict
     with io.StringIO() as f:
         writer = csv.DictWriter(f, fieldnames=csvdict['header'])
         writer.writerows(csvdict['rows'])


### PR DESCRIPTION
Adds webview support for static tabular data provided as CSV.

Currently only used as a custom plot option, but could also be used to create standard tabs containing tabular data (most immediately a parameter statistics tab showing 68% and 95% CIs on the fit parameters).

This implementation is extremely lightweight and extensible:
1. The base python CSV parser is used to generate header and row data
2. I made a new Vue component to render the table from the parsed data and allow the user to download the raw data (note that the raw data are included along with the parsed data to avoid an extraneous server call; I imagine we'll mostly be dealing with small tables so the duplication makes sense).

Screenshot (formatting / contents controlled by source, not the webview renderer):

![image](https://github.com/user-attachments/assets/57ed88d5-7715-4849-96c3-c9df0574c453)

