### PR TITLE
Webview: Ensure fit complete handler runs after uncertainty_final event handled

### DIFF
--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -499,10 +499,6 @@ async def _fit_complete_handler(event):
         await log(event["info"], title=f"done with chisq {chisq}")
         logger.info(f"fit done with chisq {chisq}")
 
-    if fit_thread.fitclass.id == 'dream':
-        # print("waiting for uncertainty to complete...")
-        await asyncio.to_thread(state.fit_uncertainty_final.wait)
-
     state.fit_complete_event.set()
 
     if terminate:
@@ -515,6 +511,8 @@ def fit_progress_handler(event: Dict):
 
 def fit_complete_handler(event: Dict):
     loop = getattr(state, 'calling_loop', None)
+    if event["message"] != "error":
+        state.fit_uncertainty_final.wait()
     if loop is not None:
         asyncio.run_coroutine_threadsafe(_fit_complete_handler(event), loop)
 

--- a/bumps/webview/server/fit_thread.py
+++ b/bumps/webview/server/fit_thread.py
@@ -158,15 +158,14 @@ class DreamMonitor(monitor.Monitor):
         """
         Close out the monitor
         """
-        if self.uncertainty_state is not None:
-            # Note: win.uncertainty_state protected by win.fit_lock
-            # self.win.uncertainty_state = self.uncertainty_state
-            evt = dict(
-                message="uncertainty_final",
-                time=self.time,
-                uncertainty_state=deepcopy(self.uncertainty_state),
-            )
-            EVT_FIT_PROGRESS.send(evt)
+        # Note: win.uncertainty_state protected by win.fit_lock
+        # self.win.uncertainty_state = self.uncertainty_state
+        evt = dict(
+            message="uncertainty_final",
+            time=self.time,
+            uncertainty_state=deepcopy(self.uncertainty_state),
+        )
+        EVT_FIT_PROGRESS.send(evt)
 
 # ==============================================================================
 


### PR DESCRIPTION
The fit_complete handler in the webview API is intended to be the last thing that runs at the end of a fit.

The signals and locks were not enforcing this.  This PR moves `fit_uncertainty_final.wait` to run before the start of execution of the fit_complete handler.

Related, it also causes the DREAM monitor to always emit the `uncertainty_final` progress event, even if no uncertainty is defined (if `uncertainty_state == None`).