### PR TITLE
Optional persistent path

### DIFF
--- a/extra/platform_scripts/bumps_webview.app/bumps_webview
+++ b/extra/platform_scripts/bumps_webview.app/bumps_webview
@@ -5,7 +5,7 @@ on run argv
       set base_path to container of (container of (path to me)) as alias
    end tell
    set env_activate to "source " & quoted form of ((POSIX path of base_path) & "env/bin/activate") & ";"
-   set run_server_and_terminate to ( " python" & " -m" & " bumps.webview.server;" & " exit;")
+   set run_server_and_terminate to ( " python" & " -m" & " bumps.webview.server --use_persistent_path;" & " exit;")
    if application "Terminal" is not running then
       tell application "Terminal"
          activate

--- a/extra/platform_scripts/bumps_webview.bat
+++ b/extra/platform_scripts/bumps_webview.bat
@@ -1,4 +1,4 @@
 @echo off
 rem start "Bumps Web GUI" 
 call "%~dp0env\Scripts\activate.bat"
-start "Bumps Webview" "python.exe" "-m" "bumps.webview.server"
+start "Bumps Webview" "python.exe" "-m" "bumps.webview.server" "--use_persistent_path"

--- a/extra/platform_scripts/make_linux_desktop_shortcut.sh
+++ b/extra/platform_scripts/make_linux_desktop_shortcut.sh
@@ -14,7 +14,7 @@ script_dir=$(realpath $(dirname $0))
 echo "[Desktop Entry]
 Name=Bumps-Webview
 Comment=Start the bumps webview server
-Exec='$script_dir/env/bin/python' -m bumps.webview.server
+Exec='$script_dir/env/bin/python' -m bumps.webview.server --use_persistent_path
 Icon=$script_dir/env/share/icons/bumps-icon.svg
 Terminal=true
 Type=Application


### PR DESCRIPTION
Add startup flag to make usage of the persistent path optional.

The primary use case of the persistent path will probably be people starting the application from a shortcut, so that they can quickly navigate to the same folder they were previously using.

For users on the command line, it would be more convenient to use the current working directory, so the flag is False by default, but enabled in all the shortcuts that are deployed.