### PR TITLE
fall back to current working directory if state.base_path does not exist

### DIFF
--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -898,9 +898,13 @@ async def get_dirlisting(pathlist: Optional[List[str]]=None):
     subfolders = []
     files = []
     path = Path(state.base_path) if (pathlist is None or len(pathlist) == 0) else Path(*pathlist)
+    if not path.exists():
+        await add_notification(
+            f"Path does not exist: {path}, falling back to current working directory", 
+            title="Error", timeout=2000)
+        path = Path.cwd()
+
     abs_path = path.absolute()
-    if not abs_path.exists():
-        return { "error": f"Path does not exist: {abs_path}" }
     for p in abs_path.iterdir():
         if not p.exists():
             continue


### PR DESCRIPTION
An unrecoverable GUI state was occurring when users moved or deleted a folder that was the "most recent folder" persisted to disk (base_path), then tried to open a model from the file browser.

The server was trying to fall back to the `base_path`, but that was the path that was missing, so the file browser never opened (it received an error message every time).

This PR removes the error message reply, which is not useful at this time, and instead falls back to the current working directory if the specified directory does not exist.