### PR TITLE
add count of displayed parameters to 'Fit Parameter' heading

### DIFF
--- a/bumps/webview/client/src/components/SummaryView.vue
+++ b/bumps/webview/client/src/components/SummaryView.vue
@@ -81,7 +81,7 @@ async function onInactive(param) {
   <table class="table table-sm">
     <thead class="border-bottom py-1 sticky-top text-white bg-secondary">
       <tr>
-        <th scope="col">Fit Parameter</th>
+        <th scope="col">Fit Parameter ({{ tag_filter?.filtered_parameters?.length ?? 0 }})</th>
         <th scope="col"></th>
         <th scope="col">Value</th>
         <th scope="col">Min</th>


### PR DESCRIPTION
In the Summary tab of the webview gui, show how many fit parameters are being shown in parentheses in the header of the column (showing the number of filtered parameters actually being shown).

Fixes #166