### PR TITLE
Fix bug where you can't initialize (frozen) Normal distribution dataclass instance

### DIFF
--- a/bumps/bounds.py
+++ b/bumps/bounds.py
@@ -51,6 +51,7 @@ functions::
 """
 from __future__ import division
 __all__ = ['pm', 'pmp', 'pm_raw', 'pmp_raw', 'nice_range', 'init_bounds',
+           'DistProtocol',
            'Bounds', 'Unbounded', 'Bounded', 'BoundedAbove', 'BoundedBelow',
            'Distribution', 'Normal', 'BoundedNormal', 'SoftBounded']
 
@@ -556,6 +557,10 @@ class Bounded(Bounds):
 
 
 class DistProtocol(Protocol):
+    """
+    Protocol for a distribution object, implementing the scipy.stats interface.
+    (also including args, kwds and name)
+    """
     name: str
     args: Tuple[float, ...]
     kwds: Dict[str, Any]
@@ -571,9 +576,8 @@ class Distribution(Bounds):
     """
     Parameter is pulled from a distribution.
 
-    *dist* must implement the distribution interface from scipy.stats.
-    In particular, it should define methods rvs, nnlf, cdf and ppf and
-    attributes args and dist.name.
+    *dist* must implement the distribution interface from scipy.stats,
+    described in the DistProtocol class.
     """
 
     dist: DistProtocol = None

--- a/bumps/bounds.py
+++ b/bumps/bounds.py
@@ -895,3 +895,14 @@ def _put01_inf(v):
     return x
 
 BoundsType = Union[Unbounded, Bounded, BoundedAbove, BoundedBelow, BoundedNormal, SoftBounded, Normal]
+
+def test_normal():
+    """
+    Test the normal distribution
+    """
+    epsilon = 1e-10
+    n = Normal(mean=0.5, std=1.0)
+    assert abs(n.nllf(0.5) - 0.9189385332046727) < epsilon
+    assert abs(n.nllf(1.0) - n.nllf(0.0)) < epsilon
+    assert abs(n.residual(0.5) - 0.0) < epsilon
+    assert abs(n.residual(1.0) - 0.5) < epsilon


### PR DESCRIPTION
Currently, attempting to use the `bumps.bounds.Normal` distribution results in an exception during initialization of the class, because the initialization of the ancestor `Distribution` class does `self.dist = dist`, which is forbidden on a frozen dataclass.

Instead, we can use `__post_init__` with `object.__setattr__` during initialization to write to private attributes