### PR TITLE
Fix gaussian mixture example

### DIFF
--- a/bumps/dream/model.py
+++ b/bumps/dream/model.py
@@ -242,4 +242,5 @@ class Mixture(MCMCModel):
 
     def nllf(self, x):
         p = [w*exp(-M.nllf(x)) for M, w in self.pairs]
-        return -log(np.sum(p)/self.weight)
+        total = np.sum(p)/self.weight
+        return -log(total) if total > 0 else 1e100

--- a/bumps/dream/model.py
+++ b/bumps/dream/model.py
@@ -237,7 +237,7 @@ class Mixture(MCMCModel):
                 or not all(hasattr(M, 'nllf') for M in models)
                 or not all(np.isscalar(w) for w in weights)):
             raise TypeError("Expected MixtureModel(M1, w1, M2, w2, ...)")
-        self.pairs = zip(models, weights)
+        self.pairs = tuple(zip(models, weights))
         self.weight = np.sum(w for w in weights)
 
     def nllf(self, x):

--- a/bumps/dream/views.py
+++ b/bumps/dream/views.py
@@ -204,6 +204,7 @@ def plot_logp(state, portion=None):
 
     # Plot long likelihood histogram
     data = logp[start:].flatten()
+    data = data[np.isfinite(data)]
     hist = axes([margin+width+delta, 0.1, 1-2*margin-width-delta, height])
     hist.hist(data, bins=40, orientation='horizontal', density=True)
     hist.set_ylim(trace.get_ylim())

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -351,6 +351,7 @@ class FitProblem:
         Returns True if the value is valid and the parameters were set,
         otherwise returns False.
         """
+        #print("Calling setp with", pvec, self._parameters)
         # TODO: do we have to leave the model in an invalid state?
         # WARNING: don't try to conditionally update the model
         # depending on whether any model parameters have changed.
@@ -430,7 +431,7 @@ class FitProblem:
 
         pparameter, pconstraints, pmodel, failing_constraints = self._nllf_components()
         cost = pparameter + pconstraints + pmodel
-        # print(pvec, "cost=",pparameter,"+",pconstraints,"+",pmodel,"=",cost)
+        #print("cost=",pparameter,"+",pconstraints,"+",pmodel,"=",cost, pvec)
         if isnan(cost):
             # TODO: make sure errors get back to the user
             # print "point evaluates to nan"
@@ -498,7 +499,7 @@ class FitProblem:
             # since inf <= inf is True but inf < inf is False.
             penalty_nllf = self.penalty_nllf if self.penalty_nllf is not None else np.inf
             pmodel = self.model_nllf() if len(failing_constraints) == 0 else penalty_nllf
-                     
+
             return pparameter, pconstraints, pmodel, failing_constraints
         except Exception:
             # TODO: make sure errors get back to the user
@@ -539,7 +540,7 @@ class FitProblem:
         If the set of fit parameters changes, then model_reset must
         be called.
         """
-        # print self.model_parameters()
+        #print("In model reset with", self.model_parameters())
         all_parameters = parameter.unique(self.model_parameters())
         # print "all_parameters",all_parameters
         # for p in all_parameters:
@@ -551,7 +552,7 @@ class FitProblem:
         for p in all_parameters:
             # slot = p.slot
             # value = p.value
-            
+
             # TODO: this is a shim to accomodate Expression, Calculation etc. being
             # put into attributes that have type "Parameter" (in user scripts)
             # Do we cause those scripts to break instead?  

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -219,7 +219,7 @@ class SupportsPrior:
                 prior = mbounds.Bounded(lo, hi)
         else:
             raise ValueError("no distribution found matching %s" % (str(distribution)))
-        
+
         self.prior = prior
 
 
@@ -314,7 +314,7 @@ class Parameter(ValueProtocol, SupportsPrior):
     distribution: DistributionType = field(default_factory=Uniform)
     discrete: bool = False
     tags: List[str] = field(default_factory=list)
-    
+
     _fixed: bool
 
     def parameters(self):

--- a/bumps/pdfwrapper.py
+++ b/bumps/pdfwrapper.py
@@ -12,8 +12,6 @@ of the function in whatever way is meaningful.
 The note regarding user defined functions in :mod:`bumps.curve` apply
 here as well.
 """
-from __future__ import print_function
-
 import inspect
 
 import numpy as np
@@ -23,7 +21,7 @@ from .fitproblem import Fitness
 from .bounds import init_bounds
 
 
-class PDF(object):
+class PDF:
     """
     Build a model from a function.
 
@@ -85,8 +83,11 @@ class PDF(object):
         self._function = fn
         self._labels = labels
         self._plot = plot
+        self.name = name if name else "PDF"
 
     def parameters(self):
+        # Note: need to refetch the pars from self in case the user assigned
+        # model.par = new_parameter after creating the model.
         return dict((p, getattr(self, p)) for p in self._labels)
     parameters.__doc__ = Fitness.parameters.__doc__
 
@@ -116,7 +117,7 @@ class PDF(object):
     numpoints.__doc__ = Fitness.numpoints.__doc__
 
 
-class VectorPDF(object):
+class VectorPDF:
     """
     Build a model from a function.
 
@@ -168,8 +169,11 @@ class VectorPDF(object):
         self._function = fn
         self._labels = labels
         self._plot = plot
+        self.name = name if name else "VectorPDF"
 
     def parameters(self):
+        # Note: need to refetch the pars from self in case the user assigned
+        # model.par = new_parameter after creating the model.
         return dict((k, getattr(self, k)) for k in self._labels)
     parameters.__doc__ = Fitness.parameters.__doc__
 

--- a/doc/examples/test_functions/mixture.py
+++ b/doc/examples/test_functions/mixture.py
@@ -28,33 +28,45 @@ so *S* < 1e-4 cannot be modeled reliably.
 Population size *h* is set to 20 per mode.  A good choice for number of
 sequences *k* is not yet determined.
 """
-from __future__ import print_function
-
 import numpy as np
 from bumps.dream.model import MVNormal, Mixture
 from bumps.names import *
 from bumps.util import push_seed
 
-def make_model():
-    if 1: # Fixed layout of 5 minima
+def make_model(dims=10):
+    """
+    Adjust S (sigma^2) to change the diameter of the peak
+
+    Small values of sigma lead to stuck fits.
+
+    Adjust relative intensity of peaks with I.
+
+    Choose peak spacing with x. Keep it between -10 and 20
+
+    The peaks are located in a hypercube of dimension d, with coordinates in
+    each dimension a random permutation of x. That means the resulting histogram
+    which is a projection along that dimension will contain a random permutation
+    of peak heights, with centers at the x positions. The 2D histograms will be
+    be similar random permutations.
+    """
+    if 1: # Uneven spacing of 5 peaks
+        num_modes = 5
+        S = [0.1]*5
+        x = [1, 3, 7, 14, 18]
+        I = [2.5, 1, 5, 4, 1]
+        #S[2] = 0.05; I[2] = 60
+    elif 1: # Even spacing of 5 peaks
         num_modes = 5
         S = [0.1]*5
         x = [-4, -2, 0, 2, 4]
-        y = [2, -2, -4, 0, 4]
-        I = [5, 2.5, 1, 4, 1]
-    else: # Semirandom layout of n minima
+        I = [15, 2.5, 1, 4, 1]
+    else: # Lots of evenly spaced peaks
         num_modes = 40
         S = [0.1]*num_modes
-        x = np.linspace(-10, 10, num_modes)
-        y = np.random.permutation(x)
+        x = np.linspace(-9, 9, num_modes)
         I = 2*np.linspace(-1, 1, num_modes)**2 + 1
 
-    ## Take only the first two modes
-    k = 2
-    S, x, y, I = S[:k], x[:k], y[:k], I[:k]
-    #S[1] = 1; I[1] = 1; I[0] = 1
-    dims = 10
-    centers = [x, y] + [np.random.permutation(x) for _ in range(2, dims)]
+    centers = [x] + [np.random.permutation(x) for _ in range(1, dims)]
     centers = np.asarray(centers).T
     args = [] # Sequence of density, weight, density, weight, ...
     for mu_i, Si, Ii in zip(centers, S, I):
@@ -72,8 +84,9 @@ def make_model():
     return model
 
 # Need reproducible models if we want to be able to resume a fit
+dims = 6
 with push_seed(1):
-    model = make_model()
+    model = make_model(dims=dims)
 
 def plot2d(fn, args=None, range=(-10, 10)):
     """
@@ -112,7 +125,7 @@ def plot2d(fn, args=None, range=(-10, 10)):
     return plotter
 
 
-M = VectorPDF(model.nllf, p=[0.]*dims, plot=plot2d(model.nllf))
+M = VectorPDF(model.nllf, p=[1.]*dims, plot=plot2d(model.nllf))
 for _, p in M.parameters().items():
-    p.range(-10, 10)
+    p.range(-10, 20)
 problem = FitProblem(M)


### PR DESCRIPTION
The gaussian mixture example demonstrates that the dream fitter can return the correct posterior distribution.

It was broken in python 3 since zip returns an iterator that is being looped multiple times. The iterator is now turned into a tuple.

A slight tweak to the plotting for when there are bad values for log probability: clear these values before creating the histogram.