### PR TITLE
Update vite.config.js

### DIFF
--- a/bumps/webview/client/vite.config.js
+++ b/bumps/webview/client/vite.config.js
@@ -6,4 +6,9 @@ import vue from "@vitejs/plugin-vue";
 export default defineConfig({
   plugins: [vue(), svgLoader()],
   base: "",
+  define: {
+    // By default, Vite doesn't include shims for NodeJS.
+    // Plotly fails to load without this shim.
+    global: {},
+  },
 });


### PR DESCRIPTION
It looks like plotly (indirectly, via `has-hover`) requires a definition of `global` to work, otherwise the page won't load