### PR TITLE
Add application schema to serialized metadata, helps with application model migration

### DIFF
--- a/bumps/__init__.py
+++ b/bumps/__init__.py
@@ -17,6 +17,8 @@ try:
 except ImportError:
     __version__ = "unknown"
 
+__schema_version__ = "1"
+
 def data_files():
     """
     Return the data files associated with the package for setup_py2exe.py.

--- a/bumps/plugin.py
+++ b/bumps/plugin.py
@@ -38,6 +38,7 @@ __all__ = [
     'show_errors',
     'data_view',
     'model_view',
+    'migrate_serialized',
 ]
 
 # TODO: refl1d wants to do the following after cli.getopts()
@@ -110,3 +111,13 @@ def model_view():
     Return None if not present.
     """
     return None
+
+
+def migrate_serialized(model_dict):
+    """
+    Migrate serialized model to the current version.
+
+    This function is called when loading a model from a file.  It is
+    used to update the model to the current version of the plugin.
+    """
+    return model_dict

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -10,7 +10,8 @@ import os
 import tempfile
 from pathlib import Path
 from threading import Event
-from bumps.serialize import serialize, deserialize, migrate
+from bumps.serialize import serialize, deserialize
+from bumps.util import get_libraries
 import h5py
 import numpy as np
 
@@ -61,8 +62,7 @@ def serialize_problem(problem: 'bumps.fitproblem.FitProblem', method: SERIALIZER
 def deserialize_problem(serialized: bytes, method: SERIALIZERS):
     if method == 'dataclass':
         serialized_dict = json.loads(serialized)
-        final_version, migrated = migrate(serialized_dict)
-        return deserialize(migrated)
+        return deserialize(serialized_dict, migration=True)
     elif method == 'pickle':
         import pickle
         return pickle.loads(serialized)
@@ -158,6 +158,7 @@ class ProblemState:
         group = parent.require_group('problem')
         write_fitproblem(group, 'fitProblem', self.fitProblem, self.serializer)
         write_string(group, 'serializer', self.serializer)
+        write_json(group, 'libraries', get_libraries(self.fitProblem))
         # write_json(group, 'pathlist', self.pathlist)
         # write_string(group, 'filename', self.filename)
 


### PR DESCRIPTION
This PR 
- adds a new `libraries` property to the serialized JSON format for models, which provides a `version` string and `schema` string for the libraries from which serialized dataclasses are made for a particular model.
- adds a new `migrate_serialized(serialized_obj: bytes)` method to the interface of `bumps.plugin`, to support application-specific model migration prior to deserialization.

During the serialization, a library of package metadata is created.  As the model tree is walked, as each dataclass encountered is inspected to see which python package corresponds to the module and class it represents.  If that package has not yet bet added to the metadata, the version is extracted from the package and the `__schema_version__` attribute is read from the base module of the class path, to populate an entry 
```
"libraries": { 
    "package-name": { 
        "version": "version_string", 
        "schema": "schema_string or None",
    }
}
```

This dictionary is also written to the HDF serialization of the webview session file, in the "problem" group (readable without deserializing the problem)