### PR TITLE
Fix model select in webview data panel

### DIFF
--- a/bumps/webview/client/src/components/DataView.vue
+++ b/bumps/webview/client/src/components/DataView.vue
@@ -12,7 +12,8 @@ const plot_div = ref<HTMLDivElement | null>(null);
 const plot_div_id = ref(`div-${uuidv4()}`);
 const show_multiple = ref(false);
 const model_names = ref<string[]>([]);
-const current_models = ref<number[][]>([[0]]);
+const current_models = ref<number[]>([0]);
+const current_model = ref(0);
 
 const props = defineProps<{
   socket: AsyncSocket;
@@ -26,7 +27,9 @@ async function get_model_names() {
     return;
   }
   model_names.value = new_names;
-  current_models.value = [[0]]; //Array.from({length: num_models}).map((_, i) => [i]);
+  const new_model = Math.min(current_model.value, model_names.value.length - 1);
+  current_models.value = [new_model];
+  current_model.value = new_model;
 }
 
 props.socket.on("model_loaded", get_model_names);
@@ -35,7 +38,8 @@ onMounted(async () => {
 });
 
 async function fetch_and_draw() {
-  const payload = await props.socket.asyncEmit("get_data_plot", current_models.value.flat());
+  const models = show_multiple.value ? current_models.value : [current_model.value];
+  const payload = await props.socket.asyncEmit("get_data_plot", models);
   let { fig_type, plotdata } = payload as { fig_type: "plotly" | "mpld3"; plotdata: object };
   if (fig_type === "plotly") {
     const { data, layout } = plotdata as Plotly.PlotlyDataLayoutConfig;
@@ -50,14 +54,21 @@ async function fetch_and_draw() {
 }
 
 function toggle_multiple() {
-  if (!show_multiple.value) {
+  if (show_multiple.value) {
+    current_models.value = [current_model.value];
+  } else {
     // then we're toggling from multiple to single...
-    current_models.value.splice(0, current_models.value.length - 1);
+    current_model.value = current_models.value.splice(-1)[0] ?? 0;
     draw_requested.value = true;
   }
+
   if (plot_div.value) {
     Plotly.Plots.resize(plot_div.value);
   }
+}
+
+function changeModel() {
+  draw_requested.value = true;
 }
 </script>
 
@@ -65,16 +76,22 @@ function toggle_multiple() {
   <div class="container d-flex flex-column flex-grow-1">
     <div class="form-check">
       <label class="form-check-label pe-2" for="multiple">Show multiple</label>
-      <input id="multiple" v-model="show_multiple" class="form-check-input" type="checkbox" @change="toggle_multiple" />
+      <input
+        id="multiple"
+        v-model="show_multiple"
+        class="form-check-input"
+        type="checkbox"
+        @change="toggle_multiple()"
+      />
     </div>
     <label for="model-select">Models:</label>
-    <select
-      id="model-select"
-      :v-model="show_multiple ? current_models : current_models[0]"
-      :multiple="show_multiple"
-      @change="draw_requested = true"
-    >
-      <option v-for="(model, model_index) in model_names" :key="model_index" :value="[model_index]">
+    <select v-if="show_multiple" id="multi-model-select" v-model="current_models" multiple @change="changeModel()">
+      <option v-for="(model, model_index) in model_names" :key="model_index" :value="model_index">
+        Model {{ model_index + 1 }}: {{ model }}
+      </option>
+    </select>
+    <select v-else id="model-select" v-model="current_model" @change="changeModel()">
+      <option v-for="(model, model_index) in model_names" :key="model_index" :value="model_index">
         Model {{ model_index + 1 }}: {{ model }}
       </option>
     </select>


### PR DESCRIPTION
The data view in bumps webview was broken - selecting models was not working (nor was multiple selection).

This PR fixes that issue (models that can't overplot on the same matplotlib figure still won't properly plot if multiple is selected)