### PR TITLE
Dark mode

### DIFF
--- a/bumps/webview/client/src/App.vue
+++ b/bumps/webview/client/src/App.vue
@@ -39,10 +39,15 @@ const props = defineProps<{
 }>();
 
 const show_menu = ref(false);
-const dark_mode = window.matchMedia("(prefers-color-scheme: dark)");
-if (dark_mode.matches) {
-  document.documentElement.setAttribute("data-bs-theme", "dark");
+
+// Control Dark Mode from system media query
+const prefersDarkMediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
+function setDarkTheme(prefersDark: boolean) {
+  const theme = prefersDark ? "dark" : "light";
+  document.documentElement.setAttribute("data-bs-theme", theme);
 }
+prefersDarkMediaQueryList.addEventListener("change", (e) => setDarkTheme(e.matches));
+setDarkTheme(prefersDarkMediaQueryList.matches);
 
 // const nativefs = ref(false);
 

--- a/bumps/webview/client/src/App.vue
+++ b/bumps/webview/client/src/App.vue
@@ -39,7 +39,11 @@ const props = defineProps<{
 }>();
 
 const show_menu = ref(false);
-const dark_mode = ref(false);
+const dark_mode = window.matchMedia("(prefers-color-scheme: dark)");
+if (dark_mode.matches) {
+  document.documentElement.setAttribute("data-bs-theme", "dark");
+}
+
 // const nativefs = ref(false);
 
 // Create a SocketIO connection, to be passed to child components
@@ -107,11 +111,6 @@ socket.on("cancel_notification", cancelNotification);
 //   socket.disconnect();
 //   connected.value = false;
 // }
-
-function setMode() {
-  const theme = dark_mode.value ? "dark" : "light";
-  document.documentElement.setAttribute("data-bs-theme", theme);
-}
 
 async function selectOpenFile() {
   if (fileBrowser.value) {
@@ -376,17 +375,6 @@ file_menu_items.value = [
             </h4>
           </div>
           <div class="d-flex navbar-nav mb-2 mb-lg-0">
-            <div class="form-check form-switch nav-item m-0 p-2">
-              <input
-                id="darkModeSwitch"
-                v-model="dark_mode"
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                @change="setMode()"
-              />
-              <label class="form-check-label text-secondary" for="darkModeSwitch">dark mode</label>
-            </div>
             <div
               id="connection_status"
               class="nav-item"

--- a/bumps/webview/client/src/App.vue
+++ b/bumps/webview/client/src/App.vue
@@ -39,6 +39,7 @@ const props = defineProps<{
 }>();
 
 const show_menu = ref(false);
+const dark_mode = ref(false);
 // const nativefs = ref(false);
 
 // Create a SocketIO connection, to be passed to child components
@@ -106,6 +107,11 @@ socket.on("cancel_notification", cancelNotification);
 //   socket.disconnect();
 //   connected.value = false;
 // }
+
+function setMode() {
+  const theme = dark_mode.value ? "dark" : "light";
+  document.documentElement.setAttribute("data-bs-theme", theme);
+}
 
 async function selectOpenFile() {
   if (fileBrowser.value) {
@@ -283,7 +289,7 @@ file_menu_items.value = [
 
 <template>
   <div class="h-100 w-100 m-0 d-flex flex-column">
-    <nav v-if="single_panel === null" class="navbar navbar-expand-sm navbar-dark bg-dark">
+    <nav v-if="single_panel === null" class="navbar navbar-expand-sm bg-dark" data-bs-theme="dark">
       <div class="container-fluid">
         <div class="navbar-brand">
           <img src="./assets/bumps-icon_256x256x32.png" alt="" height="24" class="d-inline-block align-text-middle" />
@@ -369,9 +375,21 @@ file_menu_items.value = [
               </div>
             </h4>
           </div>
-          <div class="d-flex">
+          <div class="d-flex navbar-nav mb-2 mb-lg-0">
+            <div class="form-check form-switch nav-item m-0 p-2">
+              <input
+                id="darkModeSwitch"
+                v-model="dark_mode"
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                @change="setMode()"
+              />
+              <label class="form-check-label text-secondary" for="darkModeSwitch">dark mode</label>
+            </div>
             <div
               id="connection_status"
+              class="nav-item"
               :class="{ btn: true, 'btn-outline-success': connected, 'btn-outline-danger': !connected }"
             >
               {{ connected ? "connected" : "disconnected" }}

--- a/bumps/webview/client/src/components/DataView.vue
+++ b/bumps/webview/client/src/components/DataView.vue
@@ -98,3 +98,11 @@ function changeModel() {
     <div :id="plot_div_id" ref="plot_div" class="flex-grow-1"></div>
   </div>
 </template>
+
+<style>
+@media (prefers-color-scheme: dark) {
+  .mpld3-figure {
+    background-color: lightgray;
+  }
+}
+</style>


### PR DESCRIPTION
Add a button to enable dark mode for the webview client.  This capability is built-in to the Bootstrap CSS we are using, we just have to expose it by setting e.g. `document.documentElement.setAttribute("data-bs-theme", "dark")`

Result:
![image](https://github.com/user-attachments/assets/2b1549a6-895e-4380-bbd5-824f72fc5bb0)