### PR TITLE
clear uncertainty plots if returned plottable is null 

### DIFF
--- a/bumps/webview/client/src/components/CorrelationViewPlotly.vue
+++ b/bumps/webview/client/src/components/CorrelationViewPlotly.vue
@@ -53,6 +53,12 @@ async function fetch_and_draw(latest_timestamp?: string) {
   )) as Plotly.PlotlyDataLayoutConfig;
   const plotdata = { ...payload };
   const { data, layout } = plotdata;
+  if (layout == null || data == null) {
+    await Plotly.purge(plot_div.value as HTMLDivElement);
+    drawing_busy.value = false;
+    clearTimeout(show_loader);
+    return;
+  }
   const config: Partial<Plotly.Config> = {
     responsive: true,
     scrollZoom: true,

--- a/bumps/webview/client/src/components/ParameterTraceView.vue
+++ b/bumps/webview/client/src/components/ParameterTraceView.vue
@@ -45,6 +45,10 @@ async function fetch_and_draw() {
 
   let plotdata = { ...payload };
   const { data, layout } = plotdata;
+  if (data == null || layout == null) {
+    await Plotly.purge(plot_div_id.value);
+    return;
+  }
   plot_data.value = data;
   plot_layout.value = layout;
   const config: Partial<Plotly.Config> = {

--- a/bumps/webview/client/src/components/UncertaintyView.vue
+++ b/bumps/webview/client/src/components/UncertaintyView.vue
@@ -49,6 +49,10 @@ async function fetch_and_draw(latest_timestamp: string): Promise<void> {
     cache[title] = { timestamp: latest_timestamp, plotdata };
   }
   const { data, layout } = plotdata;
+  if (layout == null || data == null) {
+    await Plotly.purge(plot_div_id.value);
+    return;
+  }
   delete layout?.width;
   delete layout?.height;
   const config = { responsive: true, scrollZoom: true, modeBarButtonsToAdd: [SVGDownloadButton] };


### PR DESCRIPTION
as happens when a new fit starts and the uncertainty state is empty, and the server returns "None" for all the plots

Current behavior is to throw a client error because processing the plotdata fails when plotdata is null.