### PR TITLE
Default install client dependencies

### DIFF
--- a/bumps/webview/build_client.py
+++ b/bumps/webview/build_client.py
@@ -4,7 +4,7 @@ import shutil
 
 
 def build_client(
-    install_dependencies=False,
+    no_deps=False,
     sourcemap=False,
     cleanup=False,
 ):
@@ -17,7 +17,7 @@ def build_client(
     # check if the node_modules directory exists
     node_modules = client_folder / "node_modules"
     os.chdir(client_folder)
-    if install_dependencies or not node_modules.exists():
+    if not no_deps or not node_modules.exists():
         print("Installing node modules...")
         os.system("npm install")
 
@@ -40,12 +40,12 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Build the webview client.")
-    parser.add_argument("--install-dependencies", action="store_true", help="Install dependencies.")
+    parser.add_argument("--no-deps", action="store_false", help="Don't install npm dependencies.")
     parser.add_argument("--sourcemap", action="store_true", help="Generate sourcemaps.")
     parser.add_argument("--cleanup", action="store_true", help="Remove the node_modules directory.")
     args = parser.parse_args()
     build_client(
-        install_dependencies=args.install_dependencies,
+        no_deps=args.no_deps,
         sourcemap=args.sourcemap,
         cleanup=args.cleanup,
     )

--- a/extra/build_conda_packed.sh
+++ b/extra/build_conda_packed.sh
@@ -18,7 +18,7 @@ cd "$SCRIPT_DIR"
 conda activate "$ISOLATED_ENV"
 
 python -m pip install --no-input --no-compile "..[webview]"
-python -m "${PACKAGE_NAME:-bumps}.webview.build_client" --cleanup --install-dependencies
+python -m "${PACKAGE_NAME:-bumps}.webview.build_client" --cleanup
 
 conda deactivate
 conda-pack -p "$ISOLATED_ENV" --format=no-archive --output="$SRC_DIR/$OUTPUT"


### PR DESCRIPTION
add --no-deps flag (by default, False) to bumps.webview.build_client

This change means that `npm install` is run by default when building the client with the python helper, rather than not being run by default.

If no `node_modules` folder is found, `npm install` is still run no matter what the --no-deps flag value is.