### PR TITLE
remove unused dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,7 @@ authors = [{ name = "Paul Kienzle", email = "paul.kienzle@nist.gov" }]
 license = { file = "LICENSE.txt" }
 dependencies = [
     'numpy',
-    'scikit-learn',
     'scipy',
-    'typing_extensions>=3.7.4',
     'graphlib_backport; python_version < "3.9"',
 ]
 classifiers = [


### PR DESCRIPTION
- `scikit-learn` is used only in entropy.py, and is lazily imported in there.  It is not used in any of the main operations of the bumps library, so I don't think it should be listed as a dependency.
- `typing_extensions` isn't used at all.