### PR TITLE
Disconnected dialog refactor

### DIFF
--- a/bumps/webview/client/src/app_state.ts
+++ b/bumps/webview/client/src/app_state.ts
@@ -26,7 +26,8 @@ export const LAYOUTS = ["left-right", "top-bottom", "full"];
 export type FitSetting = { name: string; settings: object };
 
 export const socket = ref<AsyncSocket>();
-export const connected = ref(false);
+export const connecting = ref(false);
+export const disconnected = ref(false);
 export const fitOptions = ref<ModalDialog>();
 export const fileBrowser = ref<ModalDialog>();
 export const model_file = shallowRef<{ filename: string; pathlist: string[] }>();

--- a/bumps/webview/client/src/components/ServerShutdown.vue
+++ b/bumps/webview/client/src/components/ServerShutdown.vue
@@ -44,7 +44,6 @@ function cancelClose() {
       class="modal"
       tabindex="-1"
       aria-labelledby="serverShutdownLabel"
-      :open="connecting"
       :aria-hidden="!disconnected"
     >
       <div class="modal-dialog modal-dialog-centered">

--- a/bumps/webview/client/src/components/ServerShutdown.vue
+++ b/bumps/webview/client/src/components/ServerShutdown.vue
@@ -21,6 +21,7 @@ watch(disconnected, () => {
         timeRemaining.value = 0;
         window.close();
         attemptingAutoClose.value = false;
+        clearInterval(shutdownTimer.value);
       }
     }, 1000);
   } else {

--- a/bumps/webview/client/src/components/ServerShutdown.vue
+++ b/bumps/webview/client/src/components/ServerShutdown.vue
@@ -49,7 +49,7 @@ function cancelClose() {
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 id="serverShutdownLabel" class="modal-title">Disconnected</h5>
+            <h5 id="serverShutdownLabel" class="modal-title">Server disconnected</h5>
           </div>
           <div v-if="attemptingAutoClose" class="modal-body">
             <h3>Will attempt to auto-close client window...</h3>

--- a/bumps/webview/client/src/components/ServerStartup.vue
+++ b/bumps/webview/client/src/components/ServerStartup.vue
@@ -30,14 +30,12 @@ console.log("Connected handler registered.");
       class="modal show"
       tabindex="-1"
       aria-labelledby="serverStartupLabel"
-      :aria-hidden="connected"
+      :aria-hidden="!connecting"
     >
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 id="serverStartupLabel" class="modal-title">
-              {{ reconnecting ? "Disconnected" : "Server Connecting..." }}
-            </h5>
+            <h5 id="serverStartupLabel" class="modal-title">"Server Connecting..."</h5>
           </div>
           <div v-if="status_string !== undefined" class="modal-body">
             <div class="progress">

--- a/bumps/webview/client/src/components/ServerStartup.vue
+++ b/bumps/webview/client/src/components/ServerStartup.vue
@@ -35,7 +35,7 @@ console.log("Connected handler registered.");
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 id="serverStartupLabel" class="modal-title">"Server Connecting..."</h5>
+            <h5 id="serverStartupLabel" class="modal-title">Server Connecting...</h5>
           </div>
           <div v-if="status_string !== undefined" class="modal-body">
             <div class="progress">

--- a/bumps/webview/client/src/components/ServerStartup.vue
+++ b/bumps/webview/client/src/components/ServerStartup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { connected } from "../app_state.ts";
+import { connecting } from "../app_state.ts";
 import type { AsyncSocket } from "../asyncSocket.ts";
 
 const props = defineProps<{ socket: AsyncSocket }>();
@@ -24,7 +24,7 @@ console.log("Connected handler registered.");
 </script>
 
 <template>
-  <dialog ref="loading_dialog" :open="!connected">
+  <dialog ref="loading_dialog" :open="connecting">
     <div
       id="serverStartupModal"
       class="modal show"
@@ -36,10 +36,7 @@ console.log("Connected handler registered.");
         <div class="modal-content">
           <div class="modal-header">
             <h5 id="serverStartupLabel" class="modal-title">
-              Server Connecting...
-              <div v-if="percent === undefined" class="spinner-border text-primary" role="status">
-                <span class="visually-hidden">Connecting...</span>
-              </div>
+              {{ reconnecting ? "Disconnected" : "Server Connecting..." }}
             </h5>
           </div>
           <div v-if="status_string !== undefined" class="modal-body">
@@ -64,5 +61,9 @@ console.log("Connected handler registered.");
 <style scoped>
 div.modal {
   display: block;
+}
+
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
 }
 </style>

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1242,7 +1242,6 @@ async def shutdown():
     if state.mapper is not None:
         state.mapper.stop_mapper()
         state.mapper = None
-    await emit("server_shutting_down")
     # print("gather _shutdown()")
     # TODO: why gather here rather than await?
     asyncio.gather(_shutdown(), return_exceptions=True)


### PR DESCRIPTION
Currently, if the user quits the server (or it is terminated) any client window that is connected to that server shows a dialog with "Server shutting down" and a "DISMISS" button.

The button is supposed to prevent the tab/window from auto-closing, but this is not obvious to the user based on the dialog and button wording.  

Also, currently if the user clicks "DISMISS" the next thing they see is another dialog with "Server connecting..." and a spinner that spins endlessly, but even if another server is started at the same hostname/port, the client never reconnects.

This PR fixes the second issue (the client does attempt to reconnect), and also shows a more informative dialog when the server shuts down.

The PR removes the "Connected" and "Disconnected" indicators in the upper-right of the header, saving screen real estate.  A disconnected client shows a dialog indicating "Disconnected", preventing any interaction with the client parts, until a new server is available at that port.

![image](https://github.com/user-attachments/assets/67067c0f-95a5-43f9-a7a3-0cc970143a81)
