### PR TITLE
synchronize CLI fit options with the webview interface

### DIFF
--- a/bumps/webview/client/src/app_state.ts
+++ b/bumps/webview/client/src/app_state.ts
@@ -82,6 +82,7 @@ export class AutoupdateState {
     const shared_state_keys = Object.keys(this.shared_state) as (keyof SharedState)[];
     for (const key of shared_state_keys) {
       const initial_value = await socket.asyncEmit(`get_shared_setting`, key);
+      console.debug(`Received initial value for ${key}: ${JSON.stringify(initial_value, null, 2)}`);
       this.shared_state[key].value = initial_value;
     }
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -68,7 +68,12 @@ MODEL_EXT = ".json"
 TRACE_MEMORY = False
 
 
+# TODO: any other state that needs to be initialized?
+# TODO: can initialization be moved to the SharedState constructor?
+# Initialize state
 state = State()
+state.shared.fitter_id = fit_options.DEFAULT_FITTER_ID
+state.shared.fitter_settings = deepcopy(fit_options.FITTER_DEFAULTS)
 
 
 def register(fn: Callable):
@@ -546,14 +551,8 @@ async def start_fit_thread(fitter_id: str, options: Optional[Dict[str, Any]] = N
 
         # Use shared settings by default, update from any provided options
         shared_settings = state.shared.fitter_settings
-        if isinstance(shared_settings, dict) and fitter_id in shared_settings:
-            full_options = deepcopy(shared_settings[fitter_id]["settings"])
-        elif fitter_id in fit_options.FITTER_DEFAULTS:
-            # fall back to default settings if no shared settings are available
-            full_options = deepcopy(fit_options.FITTER_DEFAULTS[fitter_id]["settings"])
-        else:
-            full_options = {}
-        if options is not None:
+        full_options = shared_settings[fitter_id]["settings"].copy()
+        if options:
             full_options.update(options)
         fitclass = fit_options.lookup_fitter(fitter_id)
         fit_thread = FitThread(

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -548,9 +548,11 @@ async def start_fit_thread(fitter_id: str, options: Optional[Dict[str, Any]] = N
         shared_settings = state.shared.fitter_settings
         if isinstance(shared_settings, dict) and fitter_id in shared_settings:
             full_options = deepcopy(shared_settings[fitter_id]["settings"])
-        else:
+        elif fitter_id in fit_options.FITTER_DEFAULTS:
             # fall back to default settings if no shared settings are available
             full_options = deepcopy(fit_options.FITTER_DEFAULTS[fitter_id]["settings"])
+        else:
+            full_options = {}
         if options is not None:
             full_options.update(options)
         fitclass = fit_options.lookup_fitter(fitter_id)

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -589,6 +589,14 @@ async def start_fit_thread(fitter_id: str, options: Optional[Dict[str, Any]] = N
         state.fit_thread = fit_thread
 
 
+@register
+async def set_fit_options(fitter_id: str, options: Dict[str, Any]):
+    current_options = state.shared.fitter_settings[fitter_id]["settings"]
+    current_options.update(options)
+    # items in state.shared are not deeply reactive, so we have to explicitly notify:
+    state.shared.notify("fitter_settings")
+
+
 async def wait_for_fit_complete():
     if state.fit_thread is not None:
         await state.fit_complete_event.wait()

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1247,7 +1247,11 @@ async def get_dirlisting(pathlist: Optional[List[str]] = None):
 
 
 @register
-async def get_fitter_defaults(*args):
+async def get_fitter_defaults():
+    return _get_fitter_defaults()
+
+
+def _get_fitter_defaults():
     return {fitter.id: dict(name=fitter.name, settings=dict(fitter.settings)) for fitter in fit_options.FITTERS}
 
 

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -498,7 +498,8 @@ def interpret_fit_options(options: BumpsOptions):
     on_startup.append(lambda App: api.state.shared.set("selected_fitter", fitter_id))
     # TODO: send commandline options to the webview interface
     all_fit_options = api._get_fitter_defaults()
-    all_fit_options[fitter_id]["settings"].update(dict(fitopts))
+    if fitter_id in all_fit_options:
+        all_fit_options[fitter_id]["settings"].update(dict(fitopts))
     api.state.shared.fitter_settings = all_fit_options
 
     api.state.parallel = options.parallel

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -492,15 +492,11 @@ def interpret_fit_options(options: BumpsOptions):
     # TODO: leave fitter_id in fitopts
     # TODO: use dict rather than list of pairs for fitopts
     fitter_id = fitopts.pop("fit")
-    fitopts = list(fitopts.items())
 
     # on_startup.append(lambda App: publish('', 'local_file_path', Path().absolute().parts))
-    on_startup.append(lambda App: api.state.shared.set("selected_fitter", fitter_id))
-    # TODO: send commandline options to the webview interface
-    all_fit_options = api._get_fitter_defaults()
-    if fitter_id in all_fit_options:
-        all_fit_options[fitter_id]["settings"].update(dict(fitopts))
-    api.state.shared.fitter_settings = all_fit_options
+    api.state.shared.selected_fitter = fitter_id
+    if isinstance(api.state.shared.fitter_settings, dict) and fitter_id in api.state.shared.fitter_settings:
+        api.state.shared.fitter_settings[fitter_id]["settings"].update(fitopts)
 
     api.state.parallel = options.parallel
 

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -497,6 +497,9 @@ def interpret_fit_options(options: BumpsOptions):
     # on_startup.append(lambda App: publish('', 'local_file_path', Path().absolute().parts))
     on_startup.append(lambda App: api.state.shared.set("selected_fitter", fitter_id))
     # TODO: send commandline options to the webview interface
+    all_fit_options = api._get_fitter_defaults()
+    all_fit_options[fitter_id]["settings"].update(dict(fitopts))
+    api.state.shared.fitter_settings = all_fit_options
 
     api.state.parallel = options.parallel
 

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -15,6 +15,8 @@ FITTERS = (
 )
 DEFAULT_FITTER_ID = fitters.SimplexFit.id
 
+FITTER_DEFAULTS = {fitter.id: dict(name=fitter.name, settings=dict(fitter.settings)) for fitter in FITTERS}
+
 
 def lookup_fitter(fitter_id: str):
     # Checking the complete list of fitters, not the restricted list for webview

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -14,7 +14,9 @@ FITTERS = (
     fitters.BFGSFit,
 )
 DEFAULT_FITTER_ID = fitters.SimplexFit.id
-
+# Note: there are fitters that are not available in the default list but they
+# can still be specified on the command line. If one of these is used then it
+# needs to be advertised to webview via state.shared.fitter_settings
 FITTER_DEFAULTS = {fitter.id: dict(name=fitter.name, settings=dict(fitter.settings)) for fitter in FITTERS}
 
 
@@ -197,7 +199,7 @@ def form_fit_options_associations():
             setting.defaults.append(value)
 
 
-def update_options(options: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+def check_options(options: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
     """
     Check if the set of options is consistent for the fitter.
 
@@ -209,6 +211,7 @@ def update_options(options: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
     unknown = []
     fitter_id = options.get("fit", DEFAULT_FITTER_ID)
     # available = set(fitter.id for fitter in FITTERS)
+    # Check against all available fitters, not just the ones visibile in the interface
     available = FIT_AVAILABLE_IDS
     if fitter_id not in available:
         errors.append(f"Fitter {fitter_id} not in {', '.join(available)}. Using {DEFAULT_FITTER_ID} instead.")
@@ -216,7 +219,7 @@ def update_options(options: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
     fitter = lookup_fitter(fitter_id)
     defaults = dict(fitter.settings)
     # print(f"defaults for {fitter_id}: {defaults}")
-    new_options = {"fit": fitter_id}
+    new_options = {"fit": fitter_id, **defaults}
     for key, value in options.items():
         if key == "fit":
             # Already added.
@@ -249,57 +252,3 @@ def update_options(options: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
         # Format the skipped options nicely and add to the error list
         errors = [f"Unused fit options in {fitter_id}: {' '.join(unknown)}", *errors]
     return new_options, errors
-
-
-# TODO: remove unused parse_fit_options
-# *** Deprecated ***
-def parse_fit_options(fitter_id: str, fit_options: Optional[List[str]] = None) -> Dict:
-    FITTER_DEFAULTS = {}
-    for fitter in FITTERS:
-        FITTER_DEFAULTS[fitter.id] = {
-            "name": fitter.name,
-            "settings": dict(fitter.settings),
-        }
-    if fitter_id not in FITTER_DEFAULTS:
-        raise ValueError(f"invalid fitter: {fitter_id}")
-    fitter_settings: Dict = FITTER_DEFAULTS[fitter_id]["settings"]
-    if fit_options is not None:
-        # fit options is a list of strings of the form "key=value"
-        for option_str in fit_options:
-            parts = option_str.split("=")
-            if len(parts) != 2:
-                raise ValueError(f"invalid fit option: {option_str}, must be of form 'key=value'")
-            key, value = parts
-            if key not in fitter_settings:
-                raise ValueError(
-                    f"invalid fit option: '{key}' for fitter '{fitter_id}'; valid options are: {list(fitter_settings.keys())}"
-                )
-
-            setting = FIT_OPTIONS[key]
-            stype = setting.stype
-            if stype is int:
-                value = int(value)
-            elif stype is float:
-                value = float(value)
-            elif isinstance(stype, Range):
-                value = float(value)
-                if not stype.min <= value <= stype.max:
-                    raise ValueError(f"invalid value for {key}: {value} not in [{stype.min:g}, {stype.max:g}]")
-            elif stype is str:
-                pass
-            elif stype is bool:
-                if value.lower() in ["true", "1", "yes", "on"]:
-                    value = True
-                elif value.lower() in ["false", "0", "no", "off"]:
-                    value = False
-                else:
-                    raise ValueError(f"invalid value for {key}: '{value}'; valid options are yes and no")
-            elif isinstance(stype, list):
-                if value not in stype:
-                    raise ValueError(f"invalid value for {key}: '{value}'; valid options are: {stype}")
-            else:
-                raise ValueError(f"invalid type: {stype}")
-
-            fitter_settings[key] = value
-
-    return fitter_settings

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -708,6 +708,9 @@ class SharedState:
 
     async def set(self, name, value):
         super().__setattr__(name, value)
+        await self.notify(name, value)
+
+    async def notify(self, name, value):
         for callback in self._notification_callbacks.values():
             await callback(name, value)
 

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -708,9 +708,11 @@ class SharedState:
 
     async def set(self, name, value):
         super().__setattr__(name, value)
-        await self.notify(name, value)
+        for callback in self._notification_callbacks.values():
+            await callback(name, value)
 
-    async def notify(self, name, value):
+    async def notify(self, name, value=None):
+        value = await self.get(name)
         for callback in self._notification_callbacks.values():
             await callback(name, value)
 

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -1,5 +1,4 @@
 import asyncio
-from copy import deepcopy
 import functools
 import mimetypes
 import os
@@ -15,7 +14,6 @@ from . import api
 from . import persistent_settings
 from .logger import logger
 from .cli import BumpsOptions
-from .fit_options import FITTER_DEFAULTS
 
 matplotlib.use("agg")
 
@@ -175,11 +173,6 @@ def setup_app(options: BumpsOptions, sock: Optional[socket.socket] = None):
 
     async def notice(message: str):
         logger.info(message)
-
-    # NOTE: it is important that the fitter_settings are populated before
-    # calling interpret_fit_options, since the fitter_settings are updated
-    # with the new fitopts in that function
-    api.state.shared.fitter_settings = deepcopy(FITTER_DEFAULTS)
 
     # run setup tasks:
     on_startup, on_complete = cli.interpret_fit_options(options)

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 import functools
 import mimetypes
 import os
@@ -14,6 +15,7 @@ from . import api
 from . import persistent_settings
 from .logger import logger
 from .cli import BumpsOptions
+from .fit_options import FITTER_DEFAULTS
 
 matplotlib.use("agg")
 
@@ -174,6 +176,12 @@ def setup_app(options: BumpsOptions, sock: Optional[socket.socket] = None):
     async def notice(message: str):
         logger.info(message)
 
+    # NOTE: it is important that the fitter_settings are populated before
+    # calling interpret_fit_options, since the fitter_settings are updated
+    # with the new fitopts in that function
+    api.state.shared.fitter_settings = deepcopy(FITTER_DEFAULTS)
+
+    # run setup tasks:
     on_startup, on_complete = cli.interpret_fit_options(options)
     app.on_startup.extend(on_startup)
     app.on_cleanup.append(lambda App: notice("cleanup task"))


### PR DESCRIPTION
Populates the shared state in webview (`api.state.shared`) with all the default fit options, updated with any overrides specified on the command line e.g. when doing 
```sh
bumps model.py --fit=dream --steps=1234
```
... the number of steps shown in the fit options dialog in the webview gui will indeed be 1234.