### PR TITLE
Show final step on console and rename near_best to jump

### DIFF
--- a/bumps/bounds.py
+++ b/bumps/bounds.py
@@ -728,7 +728,7 @@ class BoundedNormal(Bounds):
             # for backward compatibility:
             lo, hi = limits
         limits = (-inf if lo is None else float(lo), inf if hi is None else float(hi))
-        # TODO: Why not use dot notation? class Bounds doesn't define __setattr__
+        # Note: Using object.__setattr__ because @dataclass(frozen) blocks setattr on BoundedNormal
         object.__setattr__(self, "lo", limits[0])
         object.__setattr__(self, "hi", limits[1])
         object.__setattr__(self, "mean", mean)

--- a/bumps/cli.py
+++ b/bumps/cli.py
@@ -138,7 +138,6 @@ def save_best(fitdriver, problem, best, view=None):
     with util.redirect_console(problem.output_path + ".err"):
         fitdriver.show()
         fitdriver.plot(output_path=problem.output_path, view=view)
-    fitdriver.show()
     # print "plotting"
 
 
@@ -713,6 +712,7 @@ def main():
         # print("time=%g"%(time.clock()-t0),file=sys.__stdout__)
         # Note: keep this in sync with the checkpoint function above
         save_best(fitdriver, problem, best, view=opts.view)
+        fitdriver.show()
         if opts.err or opts.cov:
             fitdriver.show_err()
         if opts.cov:

--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -296,7 +296,7 @@ def _run_dream(dream, abort_test=lambda: False):
     pop = state._draw_pop()
     assert pop.ctypes.data == np.ascontiguousarray(pop).ctypes.data
 
-    frame = 0
+    # frame = 0  # For debugging...
     next_outlier_test = max(state.Ngen, 2 * state.Ngen - 10)
     next_convergence_test = state.Ngen
     final_gen = dream.draws + dream.burn
@@ -466,9 +466,9 @@ def _run_dream(dream, abort_test=lambda: False):
             break
 
         # Draw the next frame (for debugging...)
-        next_frame = state.generation // state.Ngen
+        # next_frame = state.generation // state.Ngen
         # if frame != next_frame: _show_logp_frame(dream, state, next_frame)
-        frame = next_frame
+        # frame = next_frame
 
 
 def _show_logp_frame(dream, state, frame):

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -144,6 +144,8 @@ class MonitorRunner(object):
         population_points: Optional[NDArray] = None,
         population_values: Optional[NDArray] = None,
     ):
+        # Note: DEFit doesn't use MonitorRunner for config/update
+        # print(f"updating with {step} {perf_counter() - self._start} {value} {point}")
         self.history.update(
             time=perf_counter() - self._start,
             step=step,
@@ -314,6 +316,7 @@ class DEFit(FitBase):
         minimize = Minimizer(
             strategy=strategy,
             problem=self.problem,
+            # TODO: use MonitorRunner update within DE
             history=monitors.history,
             monitors=monitors.monitors,
             success=success,
@@ -1371,6 +1374,7 @@ def test_fitters():
     expected_error = [5.799e-2, 2.055e-2]
 
     for fitter_name in FIT_ACTIVE_IDS:
+        # print(f"Running {fitter_name}")
         result = fit(problem, method=fitter_name, verbose=False)
         assert np.allclose(result.x, expected_value, rtol=fit_value_tol)
         if fitter_name != "dream":

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1317,12 +1317,15 @@ def fit(problem, method=FIT_DEFAULT_ID, verbose=False, **options):
     from scipy.optimize import OptimizeResult
 
     # verbose = True
+    # Options parser stores --fit=fitter in fit_options["fit"] rather than fit_options["method"]
+    if "fit" in options:
+        method = options.pop("fit")
     if method not in FIT_AVAILABLE_IDS:
-        raise ValueError("unknown method %r not one of %s" % (method, ", ".join(sorted(FIT_ACTIVE_IDS))))
+        raise ValueError("unknown fit method %r not one of %s" % (method, ", ".join(sorted(FIT_ACTIVE_IDS))))
     for fitclass in FITTERS:
         if fitclass.id == method:
             break
-    monitors = None if verbose else []  # default is step monitor
+    monitors = None if verbose else []  # default is console monitor
     driver = FitDriver(fitclass=fitclass, problem=problem, monitors=monitors, **options)
     driver.clip()  # make sure fit starts within domain
     x, fx = driver.fit()

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -4,13 +4,8 @@ Interfaces to various optimizers.
 
 import sys
 import warnings
-from typing import List, Tuple, Any
-
-# CRUFT: time.clock() removed from python 3.8
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from typing import List, Tuple, Dict, Any, Optional
+from time import perf_counter
 
 import numpy as np
 
@@ -21,6 +16,7 @@ from . import lsqerror
 from .history import History
 from .formatnum import format_uncertainty
 from .fitproblem import nllf_scale
+from .util import NDArray
 
 from .dream import MCMCModel
 
@@ -48,6 +44,14 @@ class ConsoleMonitor(monitor.TimedUpdate):
             print(self.problem.summarize())
         finally:
             self.problem.setp(p)
+        sys.stdout.flush()
+
+    def final(self, result: Dict[str, Any], history: History):
+        self.show_progress(history)
+        self.show_improvement(history)
+
+    def info(self, message: str):
+        print(message)
         sys.stdout.flush()
 
 
@@ -115,7 +119,7 @@ class MonitorRunner(object):
     Adaptor which allows solvers to accept progress monitors.
     """
 
-    def __init__(self, monitors, problem):
+    def __init__(self, monitors: List[monitor.Monitor], problem, abort_test=None):
         if monitors is None:
             monitors = [ConsoleMonitor(problem)]
         self.monitors = monitors
@@ -123,8 +127,16 @@ class MonitorRunner(object):
         for M in self.monitors:
             M.config_history(self.history)
         self._start = perf_counter()
+        self.abort_test = abort_test if abort_test is not None else lambda: False
 
-    def __call__(self, step, point, value, population_points=None, population_values=None):
+    def __call__(
+        self,
+        step: int,
+        point: NDArray,
+        value: float,
+        population_points: Optional[NDArray] = None,
+        population_values: Optional[NDArray] = None,
+    ):
         self.history.update(
             time=perf_counter() - self._start,
             step=step,
@@ -135,6 +147,21 @@ class MonitorRunner(object):
         )
         for M in self.monitors:
             M(self.history)
+
+    def stopping(self):
+        return self.abort_test()
+
+    def info(self, message: str):
+        for M in self.monitors:
+            monitor_message = getattr(M, "info", None)
+            if monitor_message is not None:
+                monitor_message(message)
+
+    def final(self, **result):
+        for M in self.monitors:
+            monitor_final = getattr(M, "final", None)
+            if monitor_final is not None:
+                monitor_final(result, self.history)
 
 
 class FitBase(object):
@@ -194,7 +221,7 @@ class FitBase(object):
         """Fit the models and show the results"""
         self.problem = problem
 
-    def solve(self, monitors=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         raise NotImplementedError()
 
 
@@ -203,39 +230,39 @@ class MultiStart(FitBase):
     Multi-start monte carlo fitter.
 
     This fitter wraps a local optimizer, restarting it a number of times
-    to give it a chance to find a different local minimum.  If the near_best
-    option is True, then restart near the best fit, otherwise restart at
+    to give it a chance to find a different local minimum.  If the jump
+    radius is non-zero, then restart near the best fit, otherwise restart at
     random.
     """
 
     name = "Multistart Monte Carlo"
-    settings = [("starts", 100), ("near_best", True)]
+    settings = [("starts", 100), ("jump", 0.0)]
 
     def __init__(self, fitter):
         FitBase.__init__(self, fitter.problem)
         self.fitter = fitter
 
-    def solve(self, monitors=None, mapper=None, **options):
-        # TODO: need better way of tracking progress
-        import logging
-
-        starts = options.pop("starts", 1)
-        reset = not options.pop("near_best", True)
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
+        starts = max(options.pop("starts", 1), 1)
+        jump = options.pop("jump", 0.0)
         f_best = np.inf
         x_best = self.problem.getp()
-        for _ in range(max(starts, 1)):
-            logging.info("multistart round %d", _)
+        scale, err = nllf_scale(self.problem)
+        chisq_best = format_uncertainty(scale * f_best, err)
+        for k in range(starts):
             x, fx = self.fitter.solve(monitors=monitors, mapper=mapper, **options)
+            chisq = format_uncertainty(scale * fx, err)
+            monitors.info(f"fit {k+1} of {starts}: {chisq} [best={'this' if fx < f_best else chisq_best}]")
             if fx < f_best:
-                x_best, f_best = x, fx
-                logging.info("multistart f(x),x: %s %s", str(fx), str(x_best))
-            if reset:
+                x_best, f_best, chisq_best = x, fx, chisq
+            if k >= starts - 1 or monitors.stopping():
+                break
+            if jump == 0.0:
                 self.problem.randomize()
             else:
-                # Jitter
-                self.problem.setp(x_best)
-                pop = initpop.eps_init(1, self.problem.getp(), self.problem.bounds(), use_point=False, eps=1e-3)
+                pop = initpop.eps_init(1, x_best, self.problem.bounds(), use_point=False, eps=jump)
                 self.problem.setp(pop[0])
+            # print(f"jump={jump} moving from {x} to {self.problem.getp()}")
         return x_best, f_best
 
 
@@ -255,16 +282,12 @@ class DEFit(FitBase):
         ("xtol", 1e-6),  # ('stop', ''),
     ]
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
-        if abort_test is None:
-            abort_test = lambda: False
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         options = _fill_defaults(options, self.settings)
         from .mystic.optimizer import de
         from .mystic.solver import Minimizer
         from .mystic import stop
 
-        if monitors is None:
-            monitors = [ConsoleMonitor(self.problem)]
         if mapper is not None:
             _mapper = lambda p, v: mapper(v)
         else:
@@ -281,19 +304,19 @@ class DEFit(FitBase):
         minimize = Minimizer(
             strategy=strategy,
             problem=self.problem,
-            history=self.history,
-            monitors=monitors,
+            history=monitors.history,
+            monitors=monitors.monitors,
             success=success,
             failure=failure,
         )
         if resume:
             self.history.restore(self.state)
-        x = minimize(mapper=_mapper, abort_test=abort_test, resume=resume)
+        x = minimize(mapper=_mapper, abort_test=monitors.stopping, resume=resume)
         # print(minimize.termination_condition())
         # with open("/tmp/evals","a") as fid:
         #   print >>fid,minimize.history.value[0],minimize.history.step[0],\
         #       minimize.history.step[0]*options['pop']*len(self.problem.getp())
-        return x, self.history.value[0]
+        return x, monitors.history.value[0]
 
     def load(self, input_path):
         self.state = load_history(input_path)
@@ -367,20 +390,20 @@ class BFGSFit(FitBase):
 
     name = "Quasi-Newton BFGS"
     id = "newton"
-    settings = [("steps", 3000), ("ftol", 1e-6), ("xtol", 1e-12), ("starts", 1), ("near_best", False)]
+    settings = [("steps", 3000), ("ftol", 1e-6), ("xtol", 1e-12), ("starts", 1), ("jump", 0.0)]
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
-        if abort_test is None:
-            abort_test = lambda: False
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         options = _fill_defaults(options, self.settings)
         from .quasinewton import quasinewton
 
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
+        def update(step, x, fx):
+            monitors(step=step, point=x, value=fx, population_points=[x], population_values=[fx])
+            return not monitors.stopping()
+
         result = quasinewton(
             fn=self.problem.nllf,
             x0=self.problem.getp(),
-            monitor=self._monitor,
-            abort_test=abort_test,
+            monitor=update,
             itnlimit=options["steps"],
             gradtol=options["ftol"],
             steptol=1e-12,
@@ -394,10 +417,6 @@ class BFGSFit(FitBase):
         #      % (code, STATUS[code], result['x'], result['fx']))
         return result["x"], result["fx"]
 
-    def _monitor(self, step, x, fx):
-        self._update(step=step, point=x, value=fx, population_points=[x], population_values=[fx])
-        return True
-
 
 class PSFit(FitBase):
     """
@@ -408,16 +427,26 @@ class PSFit(FitBase):
     id = "ps"
     settings = [("steps", 3000), ("pop", 1)]
 
-    def solve(self, monitors=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
+        from .random_lines import particle_swarm
+
         options = _fill_defaults(options, self.settings)
         if mapper is None:
             mapper = lambda x: list(map(self.problem.nllf, x))
-        from .random_lines import particle_swarm
 
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
+        def update(step, x, fx, k):
+            monitors(step=step, point=x[:, k], value=fx[k], population_points=x.T, population_values=fx)
+            return not monitors.stopping()
+
         low, high = self.problem.bounds()
         cfo = dict(
-            parallel_cost=mapper, n=len(low), x0=self.problem.getp(), x1=low, x2=high, f_opt=0, monitor=self._monitor
+            parallel_cost=mapper,
+            n=len(low),
+            x0=self.problem.getp(),
+            x1=low,
+            x2=high,
+            f_opt=0,
+            monitor=update,
         )
         npop = int(cfo["n"] * options["pop"])
 
@@ -425,10 +454,6 @@ class PSFit(FitBase):
         satisfied_sc, n_feval, f_best, x_best = result
 
         return x_best, f_best
-
-    def _monitor(self, step, x, fx, k):
-        self._update(step=step, point=x[:, k], value=fx[k], population_points=x.T, population_values=fx)
-        return True
 
 
 class RLFit(FitBase):
@@ -438,32 +463,35 @@ class RLFit(FitBase):
 
     name = "Random Lines"
     id = "rl"
-    settings = [("steps", 3000), ("pop", 0.5), ("CR", 0.9), ("starts", 20), ("near_best", False)]
+    settings = [("steps", 3000), ("pop", 0.5), ("CR", 0.9), ("starts", 20), ("jump", 0.0)]
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
-        if abort_test is None:
-            abort_test = lambda: False
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
+        from .random_lines import random_lines
+
         options = _fill_defaults(options, self.settings)
         if mapper is None:
             mapper = lambda x: list(map(self.problem.nllf, x))
-        from .random_lines import random_lines
 
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
+        def update(step, x, fx, k):
+            monitors(step=step, point=x[:, k], value=fx[k], population_points=x.T, population_values=fx)
+            return not monitors.stopping()
+
         low, high = self.problem.bounds()
         cfo = dict(
-            parallel_cost=mapper, n=len(low), x0=self.problem.getp(), x1=low, x2=high, f_opt=0, monitor=self._monitor
+            parallel_cost=mapper,
+            n=len(low),
+            x0=self.problem.getp(),
+            x1=low,
+            x2=high,
+            f_opt=0,
+            monitor=update,
         )
         npop = max(int(cfo["n"] * options["pop"]), 3)
 
-        result = random_lines(cfo, npop, abort_test=abort_test, maxiter=options["steps"], CR=options["CR"])
+        result = random_lines(cfo, npop, maxiter=options["steps"], CR=options["CR"])
         satisfied_sc, n_feval, f_best, x_best = result
 
         return x_best, f_best
-
-    def _monitor(self, step, x, fx, k):
-        # print "rl best",k, x.shape,fx.shape
-        self._update(step=step, point=x[:, k], value=fx[k], population_points=x.T, population_values=fx)
-        return True
 
 
 class PTFit(FitBase):
@@ -475,12 +503,15 @@ class PTFit(FitBase):
     id = "pt"
     settings = [("steps", 400), ("nT", 24), ("CR", 0.9), ("burn", 100), ("Tmin", 0.1), ("Tmax", 10)]
 
-    def solve(self, monitors=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         options = _fill_defaults(options, self.settings)
         # TODO: no mapper??
         from .partemp import parallel_tempering
 
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
+        def update(step, x, fx, P, E):
+            monitors(step=step, point=x, value=fx, population_points=P, population_values=E)
+            return not monitors.stopping()
+
         t = np.logspace(np.log10(options["Tmin"]), np.log10(options["Tmax"]), options["nT"])
         history = parallel_tempering(
             nllf=self.problem.nllf,
@@ -491,13 +522,9 @@ class PTFit(FitBase):
             CR=options["CR"],
             steps=options["steps"],
             burn=options["burn"],
-            monitor=self._monitor,
+            monitor=update,
         )
         return history.best_point, history.best
-
-    def _monitor(self, step, x, fx, P, E):
-        self._update(step=step, point=x, value=fx, population_points=P, population_values=E)
-        return True
 
 
 class SimplexFit(FitBase):
@@ -507,23 +534,24 @@ class SimplexFit(FitBase):
 
     name = "Nelder-Mead Simplex"
     id = "amoeba"
-    settings = [("steps", 1000), ("radius", 0.15), ("xtol", 1e-6), ("ftol", 1e-8), ("starts", 1), ("near_best", True)]
+    settings = [("steps", 1000), ("radius", 0.15), ("xtol", 1e-6), ("ftol", 1e-8), ("starts", 1), ("jump", 0.01)]
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         from .simplex import simplex
 
-        if abort_test is None:
-            abort_test = lambda: False
         options = _fill_defaults(options, self.settings)
+
         # TODO: no mapper??
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
         # print("bounds", self.problem.bounds())
+        def update(k, n, x, fx):
+            monitors(step=k, point=x[0], value=fx[0], population_points=x, population_values=fx)
+
         result = simplex(
             f=self.problem.nllf,
             x0=self.problem.getp(),
             bounds=self.problem.bounds(),
-            abort_test=abort_test,
-            update_handler=self._monitor,
+            abort_test=monitors.stopping,
+            update_handler=update,
             maxiter=options["steps"],
             radius=options["radius"],
             xtol=options["xtol"],
@@ -536,10 +564,6 @@ class SimplexFit(FitBase):
         # print("amoeba %s %s"%(result.x,result.fx))
         return result.x, result.fx
 
-    def _monitor(self, k, n, x, fx):
-        self._update(step=k, point=x[0], value=fx[0], population_points=x, population_values=fx)
-        return True
-
 
 class MPFit(FitBase):
     """
@@ -548,17 +572,14 @@ class MPFit(FitBase):
 
     name = "Levenberg-Marquardt"
     id = "lm"
-    settings = [("steps", 200), ("ftol", 1e-10), ("xtol", 1e-10), ("starts", 1), ("near_best", False)]
+    settings = [("steps", 200), ("ftol", 1e-10), ("xtol", 1e-10), ("starts", 1), ("jump", 0.0)]
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
+    def solve(self, monitors=None, mapper=None, **options):
         from .mpfit import mpfit
 
-        if abort_test is None:
-            abort_test = lambda: False
         options = _fill_defaults(options, self.settings)
         self._low, self._high = self.problem.bounds()
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
-        self._abort = abort_test
+        self._stopping = monitors.stopping
         x0 = self.problem.getp()
         parinfo = []
         for low, high in zip(*self.problem.bounds()):
@@ -580,6 +601,9 @@ class MPFit(FitBase):
                 }
             )
 
+        def update(fcn, p, k, fnorm, functkw=None, parinfo=None, quiet=0, dof=None, **extra):
+            monitors(step=k, point=p, value=fnorm)
+
         result = mpfit(
             fcn=self._residuals,
             xall=x0,
@@ -594,7 +618,7 @@ class MPFit(FitBase):
             # gtol=1e-100, # exclude gtol test
             maxiter=options["steps"],
             # Progress monitor
-            iterfunct=self._monitor,
+            iterfunct=update,
             nprint=1,  # call monitor each iteration
             quiet=True,  # leave it to monitor to print any info
             # Returns values
@@ -608,11 +632,8 @@ class MPFit(FitBase):
 
         return x, fx
 
-    def _monitor(self, fcn, p, k, fnorm, functkw=None, parinfo=None, quiet=0, dof=None, **extra):
-        self._update(k, p, fnorm)
-
     def _residuals(self, p, fjac=None):
-        if self._abort():
+        if self._stopping():
             return -1, None
 
         self.problem.setp(p)
@@ -642,16 +663,14 @@ class LevenbergMarquardtFit(FitBase):
     #    factor: initial radius
     #    diag: variable scale factors to bring them near 1
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         from scipy import optimize
 
-        if abort_test is None:
-            abort_test = lambda: False
         options = _fill_defaults(options, self.settings)
         self._low, self._high = self.problem.bounds()
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
         x0 = self.problem.getp()
         maxfev = options["steps"] * (len(x0) + 1)
+        monitors(step=0, point=x0, value=self.problem.nllf())
         result = optimize.leastsq(
             self._bounded_residuals,
             x0,
@@ -682,6 +701,7 @@ class LevenbergMarquardtFit(FitBase):
             fx = self.problem.nllf()
         else:
             fx = None
+        monitors(step=1, point=x, value=self.problem.nllf())
         return x, fx
 
     def _bounded_residuals(self, p):
@@ -716,18 +736,17 @@ class SnobFit(FitBase):
     id = "snobfit"
     settings = [("steps", 200)]
 
-    def solve(self, monitors=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         options = _fill_defaults(options, self.settings)
         # TODO: no mapper??
         from snobfit.snobfit import snobfit
 
-        self._update = MonitorRunner(problem=self.problem, monitors=monitors)
-        x, fx, _ = snobfit(self.problem, self.problem.getp(), self.problem.bounds(), fglob=0, callback=self._monitor)
-        return x, fx
+        def update(k, x, fx, improved):
+            # TODO: snobfit does have a population...
+            monitors(step=k, point=x, value=fx, population_points=[x], population_values=[fx])
 
-    def _monitor(self, k, x, fx, improved):
-        # TODO: snobfit does have a population...
-        self._update(step=k, point=x, value=fx, population_points=[x], population_values=[fx])
+        x, fx, _ = snobfit(self.problem, self.problem.getp(), self.problem.bounds(), fglob=0, callback=update)
+        return x, fx
 
 
 class DreamModel(MCMCModel):
@@ -782,16 +801,21 @@ class DreamFit(FitBase):
         self.dream_model = DreamModel(problem)
         self.state = None
 
-    def solve(self, monitors=None, abort_test=None, mapper=None, **options):
+    def solve(self, monitors: MonitorRunner, mapper=None, **options):
         from .dream import Dream
 
-        if abort_test is None:
-            abort_test = lambda: False
         options = _fill_defaults(options, self.settings)
+
+        def update(state, pop, logp):
+            # Get an early copy of the state
+            self.state = monitors.history.uncertainty_state = state
+            step = state.generation
+            x, fx = state.best()
+            monitors(step=step, point=x, value=-fx, population_points=pop, population_values=-logp)
+            return True
 
         if mapper:
             self.dream_model.mapper = mapper
-        self._update = MonitorRunner(problem=self.dream_model.problem, monitors=monitors)
 
         population = initpop.generate(self.dream_model.problem, **options)
         pop_size = population.shape[0]
@@ -808,13 +832,13 @@ class DreamFit(FitBase):
             draws=pop_size * steps,
             burn=pop_size * options["burn"],
             thinning=options["thin"],
-            monitor=self._monitor,
+            monitor=update,
             alpha=options["alpha"],
             outlier_test=options["outliers"],
             DE_noise=1e-6,
         )
 
-        self.state = sampler.sample(state=self.state, abort_test=abort_test)
+        self.state = sampler.sample(state=self.state, abort_test=monitors.stopping)
         # print("<<< Dream is done sampling >>>")
 
         self._trimmed = self.state.trim_portion() if options["trim"] else 1.0
@@ -850,14 +874,6 @@ class DreamFit(FitBase):
 
     def entropy(self, **kw):
         return self.state.entropy(portion=self._trimmed, **kw)
-
-    def _monitor(self, state, pop, logp):
-        # Get an early copy of the state
-        self.state = self._update.history.uncertainty_state = state
-        step = state.generation
-        x, fx = state.best()
-        self._update(step=step, point=x, value=-fx, population_points=pop, population_values=-logp)
-        return True
 
     def stderr(self):
         """
@@ -954,7 +970,6 @@ def _resampler(fitter, xinit, samples=100, restart=False, **options):
         # Restore the state of the problem
         fitter.problem.restore_data()
         fitter.problem.setp(xinit)
-        # fitter.problem.model_update()  # setp does model update
     return points
 
 
@@ -963,13 +978,14 @@ class FitDriver(object):
         self.fitclass = fitclass
         self.problem = problem
         self.options = options
-        self.monitors = monitors
+        self.monitors = [ConsoleMonitor()] if monitors is None else monitors
         self.abort_test = abort_test
         self.mapper = mapper if mapper else lambda p: list(map(problem.nllf, p))
         self.fitter = None
         self.result = None
 
     def fit(self, resume=None):
+        # remove cached _cov and _stderr on new fit
         if hasattr(self, "_cov"):
             del self._cov
         if hasattr(self, "_stderr"):
@@ -981,12 +997,18 @@ class FitDriver(object):
         if starts > 1:
             fitter = MultiStart(fitter)
         t0 = perf_counter()
+        # TODO: better interface for history management?
+        # Keep a handle to the fitter which has state and monitor_runner which has history
         self.fitter = fitter
-        x, fx = fitter.solve(monitors=self.monitors, abort_test=self.abort_test, mapper=self.mapper, **self.options)
-        self.time = perf_counter() - t0
-        self.result = x, fx
+        self.monitor_runner = MonitorRunner(problem=self.problem, monitors=self.monitors, abort_test=self.abort_test)
+        x, fx = fitter.solve(
+            monitors=self.monitor_runner, abort_test=self.abort_test, mapper=self.mapper, **self.options
+        )
         if x is not None:
             self.problem.setp(x)
+        self.time = perf_counter() - t0
+        self.result = x, fx
+        self.monitor_runner.final(x=x, fx=fx, dx=self.stderr(), time=self.time)
         return x, fx
 
     def clip(self):
@@ -1241,15 +1263,15 @@ def register(fitter, active=True):
 
 
 # Register the fitters
-register(SimplexFit, active=True)
-register(DEFit, active=True)
-register(DreamFit, active=True)
-register(BFGSFit, active=True)
-register(LevenbergMarquardtFit, active=True)
-register(MPFit, active=True)
-# register(PSFit, active=False)
+register(SimplexFit)
+register(DEFit)
+register(DreamFit)
+register(BFGSFit)
+register(MPFit)
 register(PTFit, active=False)
+# register(PSFit, active=False)
 # register(RLFit, active=False)
+# register(LevenbergMarquardtFit, active=True)
 # register(SnobFit, active=False)
 
 FIT_DEFAULT_ID = SimplexFit.id
@@ -1293,10 +1315,8 @@ def fit(problem, method=FIT_DEFAULT_ID, verbose=False, **options):
     monitors = None if verbose else []  # default is step monitor
     driver = FitDriver(fitclass=fitclass, problem=problem, monitors=monitors, **options)
     driver.clip()  # make sure fit starts within domain
-    x0 = problem.getp()
     x, fx = driver.fit()
     problem.setp(x)
-    dx = driver.stderr()
     if verbose:
         print("final chisq", problem.chisq_str())
         driver.show_err()

--- a/bumps/gui/fit_thread.py
+++ b/bumps/gui/fit_thread.py
@@ -94,7 +94,7 @@ class GUIMonitor(monitor.Monitor):
             wx.PostEvent(self.win, evt)
             self.time = history.time[0]
 
-    def final(self):
+    def final(self, history, best):
         """
         Close out the monitor
         """
@@ -138,7 +138,7 @@ class DreamMonitor(monitor.Monitor):
             )
             wx.PostEvent(self.win, evt)
 
-    def final(self):
+    def final(self, history, best):
         """
         Close out the monitor
         """
@@ -222,11 +222,6 @@ class FitThread(Thread):
         )
 
         x, fx = driver.fit()
-        # Give final state message from monitors
-        for M in monitors:
-            if hasattr(M, "final"):
-                M.final()
-
         with redirect_console() as fid:
             driver.show()
             captured_output = fid.getvalue()

--- a/bumps/mystic/solver.py
+++ b/bumps/mystic/solver.py
@@ -148,7 +148,7 @@ class Minimizer:
 
         Note: only used stand-alone, not within fit service
         """
-        self.time = time.time()
+        self.time = time.perf_counter()
         self.remote_time = -cpu_time()
         population = self.step() if resume else self.start()
         try:
@@ -209,7 +209,7 @@ class Minimizer:
 
         # Update the history
         self.history.update(
-            time=time.time() - self.time,
+            time=time.perf_counter() - self.time,
             cpu_time=cpu_time() + self.remote_time,
             population_points=points,
             population_values=values,

--- a/bumps/options.py
+++ b/bumps/options.py
@@ -155,7 +155,7 @@ FIT_FIELDS = dict(
     trim=("Burn-in trim", yesno),
     outliers=("Outliers", ChoiceList("none", "iqr", "grubbs", "mahal")),
     starts=("Starts", parse_int),
-    near_best=("Restart from best", yesno),
+    jump=("Jump radius", float),
 )
 
 # Make sure all settings are parseable

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -1451,15 +1451,17 @@ def summarize(pars, sorted=False):
         if not isfinite(p.value):
             bar = ["*invalid* "]
         else:
-            position = int(p.prior.get01(p.value) * 9.999999999)
             bar = ["."] * 10
-            if position < 0:
+            if p.value < p.bounds[0]:
                 bar[0] = "<"
-            elif position > 9:
+            elif p.value > p.bounds[1]:
                 bar[9] = ">"
             else:
+                position = int(p.prior.get01(p.value) * 9.999999999)
                 bar[position] = "|"
-        output.append("%40s %s %10g in %s" % (p.name, "".join(bar), p.value, p.bounds))
+        left = f"[{p.bounds[0]:g}" if np.isfinite(p.bounds[0]) else "(-inf"
+        right = f"{p.bounds[1]:g}]" if np.isfinite(p.bounds[1]) else "inf)"
+        output.append("%40s %s %10g in %s, %s" % (p.name, "".join(bar), p.value, left, right))
     return "\n".join(output)
 
 

--- a/bumps/partemp.py
+++ b/bumps/partemp.py
@@ -19,6 +19,7 @@ from numpy.random import rand, randn, randint, permutation
 def every_ten(step, x, fx, P, E):
     if step % 10:
         print(step, fx[step], x[step])
+    return True
 
 
 def parallel_tempering(nllf, p, bounds, T=None, steps=1000, CR=0.9, burn=1000, monitor=every_ten, logfile=None):
@@ -135,7 +136,9 @@ def parallel_tempering(nllf, p, bounds, T=None, steps=1000, CR=0.9, burn=1000, m
             # assert nllf(P[0]) == E[0]
 
             # Monitoring
-            monitor(step, history.best_point, history.best, P, E)
+            if not monitor(step, history.best_point, history.best, P, E):
+                break
+
             interval = 100
             if 0 and step % interval == 0:
                 print("max r", max(["%.1f" % norm(p - P[0]) for p in P[1:]]))

--- a/bumps/quasinewton.py
+++ b/bumps/quasinewton.py
@@ -245,6 +245,9 @@ def quasinewton(
         consecmax = consecmax + 1 if maxtaken else 0
         termcode = umstop(n, xc, xp, fp, gp, Sx, typf, retcode, gradtol, steptol, itncount, itnlimit, consecmax)
 
+        # Update the iteration monitor and check for user abort.
+        cancel = not monitor(x=xp, fx=fp, step=itncount)
+
         # STEP 10.6
         # If termcode is larger than zero, we found a point satisfying one
         # of the termination criteria, return from here.  Otherwise evaluate
@@ -253,7 +256,7 @@ def quasinewton(
             xf = xp  # x final
             ff = fp  # f final
 
-        elif not monitor(x=xp, fx=fp, step=itncount):
+        elif cancel:
             termcode = 6
 
         else:

--- a/bumps/quasinewton.py
+++ b/bumps/quasinewton.py
@@ -78,7 +78,6 @@ def quasinewton(
     gradtol=1e-6,
     steptol=1e-12,
     itnlimit=2000,
-    abort_test=None,
     monitor=lambda **kw: True,
 ):
     r"""
@@ -118,11 +117,9 @@ def quasinewton(
     *itnlimit* is the maximum number of steps to take before stopping.
     Default: 2000
 
-    *abort_test* is a function which tests whether the user has requested
-    abort. Default: None.
-
     *monitor(x,fx,step)* is called every iteration so that a user interface
-    function can monitor the progress of the fit.  Default: lambda \*\*kw: True
+    function can monitor the progress of the fit.  Return False if the user
+    requests stop. Default: lambda \*\*kw: True
 
 
     Returns the fit result as a dictionary:
@@ -247,9 +244,6 @@ def quasinewton(
         # Check stopping criteria (alg.7.2.1)
         consecmax = consecmax + 1 if maxtaken else 0
         termcode = umstop(n, xc, xp, fp, gp, Sx, typf, retcode, gradtol, steptol, itncount, itnlimit, consecmax)
-
-        if abort_test():
-            termcode = 6
 
         # STEP 10.6
         # If termcode is larger than zero, we found a point satisfying one

--- a/bumps/random_lines.py
+++ b/bumps/random_lines.py
@@ -22,7 +22,7 @@ def print_every_five(step, x, fx, k):
         print(step, ":", fx[k], x[k])
 
 
-def random_lines(cfo, NP, CR=0.9, epsilon=1e-10, abort_test=None, maxiter=1000):
+def random_lines(cfo, NP, CR=0.9, epsilon=1e-10, maxiter=1000):
     """
     Random lines is a population based optimizer which using quadratic
     fits along randomly oriented directions.
@@ -48,7 +48,7 @@ def random_lines(cfo, NP, CR=0.9, epsilon=1e-10, abort_test=None, maxiter=1000):
 
         *f_opt* is the target value of the optimization
 
-    *NP* is the number of fit parameters
+    *NP* is the population size
 
     *CR* is the cross-over ratio, which is the proportion of dimensions
     that participate in any random orientation vector.
@@ -82,6 +82,7 @@ def random_lines(cfo, NP, CR=0.9, epsilon=1e-10, abort_test=None, maxiter=1000):
 
     n_feval = NP
     f_best, i_best = min(zip(f, count()))
+    satisfied_sc = 0
 
     # CHECK INITIAL STOPPING CRITERIA
     if abs(cfo["f_opt"] - f_best) < epsilon:
@@ -159,14 +160,12 @@ def random_lines(cfo, NP, CR=0.9, epsilon=1e-10, abort_test=None, maxiter=1000):
         f_best, i_best = min(zip(f, count()))
         if abs(cfo["f_opt"] - f_best) < epsilon:
             satisfied_sc = 1
-            x_best = X[:, i_best]
-            return satisfied_sc, n_feval, f_best, x_best
-        if abort_test():
             break
 
-        monitor(L, X, f, i_best)
+        if not monitor(L, X, f, i_best):
+            break
 
-    return 1, n_feval, f_best, X[:, i_best]
+    return satisfied_sc, n_feval, f_best, X[:, i_best]
 
 
 def particle_swarm(cfo, NP, epsilon=1e-10, maxiter=1000):
@@ -187,15 +186,16 @@ def particle_swarm(cfo, NP, epsilon=1e-10, maxiter=1000):
 
         *x1* and *x2* are lower and upper bounds for each parameter
 
-        *monitor* is a callable which is called each iteration using
-        *callback(step, x, fx, k)*, where *step* is the iteration number,
+        *monitor(step, x, fx, k)* is called each iteration using
+        *monitor(step, x, fx, k)*, where *step* is the iteration number,
+
         *x* is the population, *fx* is value of the cost function for each
         member of the population and *k* is the index of the best point in
         the population.
 
         *f_opt* is the target value of the optimization
 
-    *NP* is the number of fit parameters
+    *NP* is the population size
 
     *epsilon* is the convergence criterion.
 
@@ -237,6 +237,7 @@ def particle_swarm(cfo, NP, epsilon=1e-10, maxiter=1000):
     n_feval = NP
     P = X[:]
 
+    satisfied_sc = 0
     f_best, i_best = min(zip(f, count()))
     for L in range(2, maxiter + 1):
         rn2 = rand(n, NP)
@@ -259,11 +260,11 @@ def particle_swarm(cfo, NP, epsilon=1e-10, maxiter=1000):
         f_best, i_best = min(zip(f, count()))
         if abs(cfo["f_opt"] - f_best) < epsilon:
             satisfied_sc = 1
-            return satisfied_sc, n_feval, f_best, X[:, i_best]
+            break
 
-        monitor(L, X, f, i_best)
+        if not monitor(L, X, f, i_best):
+            break
 
-    satisfied_sc = 0
     return satisfied_sc, n_feval, f_best, X[:, i_best]
 
 

--- a/bumps/util.py
+++ b/bumps/util.py
@@ -37,8 +37,7 @@ from numpy import ascontiguousarray as _dense
 from scipy.special import erf
 
 USE_PYDANTIC = os.environ.get("BUMPS_USE_PYDANTIC", "False") == "True"
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 
 def field_desc(description: str) -> Any:

--- a/bumps/util.py
+++ b/bumps/util.py
@@ -6,6 +6,7 @@ __all__ = ["kbhit", "profile", "pushdir", "push_seed", "redirect_console"]
 
 import os
 import sys
+import math
 import types
 from dataclasses import Field, dataclass, field, fields, is_dataclass
 from io import StringIO
@@ -440,3 +441,66 @@ def _add_to_libraries(obj, libraries: dict):
         version = getattr(sys.modules[top_level_package], "__version__", None)
         schema_version = getattr(sys.modules[top_level_package], "__schema_version__", None)
         libraries[top_level_package] = dict(version=version, schema_version=schema_version)
+
+
+def format_duration(seconds):
+    """
+    Convert seconds into a human-readable duration string.
+
+    Args:
+        seconds (float): Duration in seconds
+
+    Returns:
+        str: Formatted duration string
+    """
+    # Handle negative values
+    if seconds < 0:
+        return "-" + format_duration(-seconds)
+    elif seconds == 0:
+        return "0 seconds"
+
+    # Define time units and their conversion factors
+    units = [
+        ("year", 365.25 * 24 * 60 * 60),
+        ("week", 7 * 24 * 60 * 60),
+        ("day", 24 * 60 * 60),
+        ("hour", 60 * 60),
+        ("minute", 60),
+        ("second", 1),
+        ("millisecond", 1e-3),
+        ("microsecond", 1e-6),
+        ("nanosecond", 1e-9),
+    ]
+
+    # Find the most appropriate unit
+    for unit_name, factor in units:
+        value = abs(seconds / factor)
+        integer = int(round(value))
+        if value > 0.95:
+            if abs(value - integer) < 0.05:
+                return f"{integer} {unit_name}{'s' if integer != 1 else ''}"
+            else:
+                return f"{value:.1f} {unit_name}s"
+
+    return f"0.0 {units[-1][0]}"
+
+
+def format_duration_demo():
+    # Test cases
+    test_values = [
+        3661.5,  # Mixed hours/minutes/seconds
+        86400.25,  # Days with fractional seconds
+        24 * 60 * 60 * 1.06,  # a little over a day
+        604800.125,  # Weeks with milliseconds
+        31536061.5,  # Years with extra days
+        0.001,  # Milliseconds
+        0,  # Zero
+        -12345,  # Negative value
+    ]
+
+    for seconds in test_values:
+        print(f"{seconds:>12.3f}s → {format_duration(seconds)}")
+
+
+if __name__ == "__main__":
+    format_duration_demo()

--- a/bumps/webview/client/src/components/FitOptions.vue
+++ b/bumps/webview/client/src/components/FitOptions.vue
@@ -11,7 +11,7 @@ const selected_fitter_local = ref("amoeba");
 
 const FIT_FIELDS: { [key: string]: [string, string | string[]] } = {
   starts: ["Starts", "integer"],
-  near_best: ["Near best", "boolean"],
+  jump: ["Jump radius", "float"],
   steps: ["Steps", "integer"],
   samples: ["Samples", "integer"],
   xtol: ["x tolerance", "float"],

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -556,7 +556,7 @@ async def start_fit_thread(fitter_id: str, options: Optional[Dict[str, Any]] = N
             full_options.update(options)
         fitclass = fit_options.lookup_fitter(fitter_id)
         fit_thread = FitThread(
-            abort_event=state.fit_abort_event,
+            fit_abort_event=state.fit_abort_event,
             fitclass=fitclass,
             problem=fitProblem,
             mapper=state.mapper,
@@ -666,7 +666,7 @@ async def _fit_complete_handler(event: Dict[str, Any]):
             logger.warning(f"Fit failed with error: {event['error_string']}\n{event['traceback']}")
             return
 
-        # print("capturing results")
+        # print(event['info'])  # Needed if we are dumping fit outputs to the terminal
         problem: bumps.fitproblem.FitProblem = event["problem"]
         chisq = nice(2 * event["value"] / problem.dof)
         problem.setp(event["point"])
@@ -1293,7 +1293,8 @@ async def add_notification(content: str, title: str = "Notification", timeout: O
 
 async def _shutdown():
     # print("raising SystemExit")
-    raise SystemExit(0)
+    # raise SystemExit(0)
+    ...
 
 
 VALUE_PRECISION = 6

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Optional, Any, Callable
+from typing import Dict, List, Tuple, Any, Callable
 from textwrap import dedent
 from argparse import ArgumentTypeError
 from dataclasses import dataclass
@@ -163,12 +163,14 @@ Setting(
 # Stochastic global minimization
 Setting("starts", "Auto restarts", int, "Number of times to restart the amoeba fit.")
 Setting(
-    "near_best",
-    "Near best",
-    bool,
+    "jump",
+    "Jump radius",
+    Range(0, 0.5),
     """\
-    When running with multiple starts, restart from a random point near the
-    best minimum rather than using a completely random starting point.""",
+    When running with multiple starts, what size of jump to take between restarts.
+    Values are in [0, 0.5], representing the portion of the total range of each parameter.
+    A value of zero uses a random starting point in the range.
+    """,
 )
 
 

--- a/bumps/webview/server/fit_thread.py
+++ b/bumps/webview/server/fit_thread.py
@@ -104,7 +104,7 @@ class ConvergenceMonitor(monitor.Monitor):
             self._send_update()
             self.time = history.time[0]
 
-    def final(self):
+    def final(self, result, history):
         """
         Close out the monitor but sending any tailing convergence information
         """
@@ -160,7 +160,7 @@ class DreamMonitor(monitor.Monitor):
             # print("Dream update", evt)
             EVT_FIT_PROGRESS.send(evt)
 
-    def final(self):
+    def final(self, result, history):
         """
         Close out the monitor
         """
@@ -181,7 +181,7 @@ class FitThread(Thread):
 
     def __init__(
         self,
-        abort_event: Event,
+        fit_abort_event: Event,
         problem=None,
         fitclass=None,
         options=None,
@@ -190,12 +190,13 @@ class FitThread(Thread):
         convergence_update=5,
         uncertainty_update=300,
         console_update=0,
+        # outputs=None,
     ):
         # base class initialization
         # Process.__init__(self)
 
         Thread.__init__(self)
-        self.abort_event = abort_event
+        self.fit_abort_event = fit_abort_event
         self.problem = problem
         self.fitclass = fitclass
         # print(f"   *** FitThread {options}")
@@ -205,13 +206,14 @@ class FitThread(Thread):
         self.convergence_update = convergence_update
         self.uncertainty_update = uncertainty_update
         self.console_update = console_update
+        # self.outputs = {} if outputs is None else outputs
 
         # Setting daemon to true causes sys.exit() to kill the thread immediately
         # rather than waiting for it to complete.
         self.daemon = True
 
     def abort_test(self):
-        return self.abort_event.is_set()
+        return self.fit_abort_event.is_set()
 
     def run(self):
         # TODO: we have no interlocks on changes in problem state.  What
@@ -272,13 +274,19 @@ class FitThread(Thread):
             )
 
             x, fx = driver.fit()
-            # Give final state message from monitors
-            for M in monitors:
-                if hasattr(M, "final"):
-                    M.final()
 
             with redirect_console() as fid:
                 driver.show()
+                # entropy = self.outputs.get('entropy', None)
+                # err = self.outputs.get('err', False)
+                # cov = self.outputs.get('cov', False)
+                # if cov:
+                #     driver.show_err()
+                #     driver.show_cov()
+                # elif err:
+                #     driver.show_err()
+                # if entropy:
+                #     driver.show_entropy(entropy)
                 captured_output = fid.getvalue()
 
             # print("fit complete with", x, fx)

--- a/bumps/webview/server/fit_thread.py
+++ b/bumps/webview/server/fit_thread.py
@@ -104,7 +104,7 @@ class ConvergenceMonitor(monitor.Monitor):
             self._send_update()
             self.time = history.time[0]
 
-    def final(self, result, history):
+    def final(self, history, best):
         """
         Close out the monitor but sending any tailing convergence information
         """
@@ -160,7 +160,7 @@ class DreamMonitor(monitor.Monitor):
             # print("Dream update", evt)
             EVT_FIT_PROGRESS.send(evt)
 
-    def final(self, result, history):
+    def final(self, history, best):
         """
         Close out the monitor
         """

--- a/check_fitters.py
+++ b/check_fitters.py
@@ -8,11 +8,9 @@ import sys
 import os
 from os.path import join as joinpath
 import tempfile
-import glob
 import subprocess
 from pathlib import Path
 import h5py
-import numpy as np
 
 sys.dont_write_bytecode = True
 
@@ -83,6 +81,7 @@ def run_fits(model_args, path, fitters=FIT_AVAILABLE_IDS, seed=1, target=0):
 
 
 def main():
+    # Note: bumps.fitters.test_fitters already runs curvefit on the "active" fitters
     fitters = sys.argv[1:] if len(sys.argv) > 1 else FIT_AVAILABLE_IDS
     # TODO: use a test function that defines residuals
     test_functions = EXAMPLEDIR / "test_functions" / "model.py"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,8 @@ nitpick_ignore = [
     ("py:class", "type"),
     ("py:class", "enum.Enum"),
     ("py:class", "object"),
+    ("py:class", "numpy.dtype"),
+    ("py:class", "numpy._typing._array_like._ScalarType_co"),
     ("py:class", "numpy.ndarray"),
     ("py:class", "np.ndarray"),
     ("py:class", "Real"),

--- a/doc/sitedoc.py
+++ b/doc/sitedoc.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 
-import bumps.fitters as fit
+from bumps import fitters
 from bumps.cli import load_model
 
 SEED = 1
@@ -56,15 +56,16 @@ def fit_model(filename):
 
     # import sys; print >>sys.stderr, "in plot with",filename, example_dir()
     np.random.seed(SEED)
-    p = load_model(os.path.join(example_dir(), filename))
-    # x.fx = fit.RLFit(p).solve(steps=1000, burn=99)
-    # x,fx = fit.DEFit(p).solve(steps=200, pop=10)
-    # x,fx = fit.PTFit(p).solve(steps=100,burn=400)
-    # x.fx = fit.BFGSFit(p).solve(steps=200)
-    x, fx = fit.SimplexFit(p).solve(steps=1000)
-    chisq = p(x)
+    problem = load_model(os.path.join(example_dir(), filename))
+    # x, fx = fit.RLFit(problem).solve(steps=1000, burn=99)
+    # x, fx = fit.DEFit(problem).solve(steps=200, pop=10)
+    # x, fx = fit.PTFit(problem).solve(steps=100,burn=400)
+    # x, fx = fit.BFGSFit(problem).solve(steps=200)
+    # x, fx = fit.SimplexFit(problem).solve(steps=1000)
+    result = fitters.fit(problem, method="amoeba", verbose=False, steps=1000)
+    chisq = problem(result.x)
     print("chisq=%g" % chisq)
     if chisq > 2:
         raise RuntimeError("Fit did not converge")
-    p.plot()
+    problem.plot()
     plt.show()


### PR DESCRIPTION
Refactor the interaction between the fitters and controller.

MonitorRunner now includes info() for updates to the user during the fit and final() for updates at the end of the fit which are forwarded to each monitor.

MonitorRunner now includes stopping() so that the fitter can ask if the abort flag has been set. This replaces the abort_test parameter passed to each fitter. [It doesn't save much code, but it makes clear that MonitorRunner is handling bidirectional communication between the controller and the fitter.]

The fitters were all adapted to accept this interface. The internals of several fitters were already set up to look at the output of the monitor update to determine if the user requested stop. For these fitters, the redundant abort_test parameter was removed. [The abort_test interface is easier to understand; in retrospect I should have removed the test against monitor update return value.]

Adapting multistart fits to info() revealed some problems in the interface. In particular, that the user couldn't specify the jump distance. The `--near_best` option was renamed `--jump=radius`.

Testing the updates somehow showed that get01/put01 wasn't working for indefinite intervals. The fix is included in this patch. getfull/putfull was also tested and adjusted. There is still an unexpectedly high loss of precision for bounded intervals. I didn't fix it because we currently aren't using the getfull/putfull interfaces, and instead raise a "not implemented" error.

I updated the "random lines" and "particle swarm" fitters so they at least run, but they are too unreliable to include in the available fitter list.

Use the simplified fit interface in the doc build. fitters.fit() now accepts fit="fitter" as well as method="fitter" so that the dictionary produced by the argument parser can be used directly. [Note: refl1d/doc/sitedoc.py will require the same changes as in bumps]