### PR TITLE
Client fit fields from server

### DIFF
--- a/bumps/webview/client/src/components/FitOptions.vue
+++ b/bumps/webview/client/src/components/FitOptions.vue
@@ -111,6 +111,13 @@ function validate(value: any, field_name: string) {
   }
   if (field_type === "integer" && parseInt(value, 10) != float_value) {
     return false;
+  } else if (typeof field_type === "object") {
+    if ("min" in field_type && float_value < field_type.min) {
+      return false;
+    }
+    if ("max" in field_type && float_value > field_type.max) {
+      return false;
+    }
   }
   return true;
 }

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1323,6 +1323,11 @@ async def get_fitter_defaults():
 
 
 @register
+async def get_fit_fields():
+    return fit_options.get_fit_fields()
+
+
+@register
 async def shutdown():
     logger.info("killing...")
     await stop_fit()

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple, Any, Callable, Optional
 from textwrap import dedent
 from argparse import ArgumentTypeError
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 
 from bumps import fitters
 from bumps.fitters import FIT_AVAILABLE_IDS
@@ -40,6 +40,7 @@ FIT_OPTIONS: Dict[str, "Setting"] = {}
 @dataclass(init=False)
 class Setting:
     name: str
+    label: str
     description: str
     stype: Callable
     fitters: List[str]
@@ -274,3 +275,20 @@ def check_options(options: Dict[str, Any], fitter_id: Optional[str] = None) -> T
         # Format the skipped options nicely and add to the error list
         errors = [f"Unused fit options in {fitter_id}: {' '.join(unknown)}", *errors]
     return new_options, errors
+
+
+def _json_compatible_setting(s: Setting):
+    output = asdict(s)
+    stype = output["stype"]
+    if stype is int:
+        output["stype"] = "integer"
+    elif stype is float:
+        output["stype"] = "float"
+    elif stype is bool:
+        output["stype"] = "boolean"
+    return output
+
+
+def get_fit_fields():
+    fit_fields = dict([(k, _json_compatible_setting(v)) for k, v in FIT_OPTIONS.items()])
+    return fit_fields


### PR DESCRIPTION
Currently the fitter fields (like steps, xtol, etc.) are defined on the server in `bumps.webview.server.fit_options`, and a matching definitions is maintained in TypeScript on the client in `bumps/webview/client/src/components/FitOptions.vue`

This PR

- adds a method that converts the FIT_OPTIONS from the server into a JSON-compatible form
- adds a method to the webview api for retrieving those fields
- refactors the FitOptions panel in the client to use these values
   - (including adding new tooltips to the labels, with the extended description!)
- removes the deprecate TS definition of FIT_FIELDS in the client code