### PR TITLE
Prevent caching webview index page

### DIFF
--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -44,7 +44,14 @@ async def index(request):
             content_type="text/html",
             status=404,
         )
-    return web.FileResponse(client / "dist" / "index.html")
+    return web.FileResponse(
+        client / "dist" / "index.html",
+        headers={
+            "Cache-Control": "max-age=0, no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )
 
 
 routes = app = sio = None


### PR DESCRIPTION
### Problem
New versions of the client are not picked up when users upgrade bumps, as the index page is often cached (by Chrome, for instance).  Within that page, there is a unique (hashed) .js library and .css files, so we only need to worry about caching of the index page.  If a fresh version of the index html is loaded, then the correct .js and .css files will be loaded too.

### Solution
send headers to prevent browsers from caching initial page, so that version changes to the client are naturally picked up

**Note** the index page is tiny, about 500 bytes, so not caching it is not a big deal.