### PR TITLE
Allow an app using bumps cli to specify a version

### DIFF
--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -393,7 +393,7 @@ def get_commandline_options(arg_defaults: Optional[Dict] = None):
         "-V",
         "--version",
         action="version",
-        version=f"%(prog)s {__version__}",
+        version=f"%(prog)s {api.state.app_version}",
     )
 
     # TODO: restructure so that -b -s -r --webview override each other
@@ -737,8 +737,9 @@ def run_batch_fit(options: BumpsOptions):
     # print("completed run")
 
 
-def plugin_main(name: str, client: Path):
+def plugin_main(name: str, client: Path, version: str = ""):
     api.state.app_name = name
+    api.state.app_version = version
     api.state.client_path = client
     main()
 

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -44,7 +44,6 @@ import logging
 from dataclasses import field
 # from textwrap import dedent
 
-from bumps import __version__
 from bumps.fitters import FIT_AVAILABLE_IDS
 from . import api
 from . import persistent_settings

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -28,6 +28,7 @@ import h5py
 import numpy as np
 from numpy.typing import NDArray
 
+from bumps import __version__
 from bumps.serialize import serialize, deserialize
 from bumps.util import get_libraries
 from .logger import logger
@@ -416,6 +417,7 @@ class FitResult:
 class State:
     # These attributes are ephemeral, not to be serialized/stored:
     app_name: str = "bumps"
+    app_version: str = __version__
     client_path: Path = Path(__file__).parent.parent / "client"
     hostname: str
     port: int


### PR DESCRIPTION
This PR adds a `version` kw argument to `cli.plugin_main`, which will be returned when the `--version` flag is used with the cli.