### PR TITLE
create public property to access FitProblem._parameters

### DIFF
--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -530,6 +530,11 @@ class FitProblem(Generic[FitnessType]):
         """Return a table of current parameter values with range bars."""
         return parameter.summarize(self._parameters)
 
+    @property
+    def parameters(self):
+        """Return the list of fitted parameters."""
+        return self._parameters
+
     def labels(self) -> util.List[str]:
         """Return the list of labels, one per fitted parameter."""
         return [p.name for p in self._parameters]


### PR DESCRIPTION
## Motivation

Many end-users of the FitProblem class need access to the fitted parameters and are using the "private" `FitProblem._parameters` attribute to get them.

We already have a `FitProblem.labels()` method that provides a list of the labels for these in the order they are stored, and this PR adds a property `FitProblem.parameters` that returns the parameters from which those labels are derived.