### PR TITLE
Fix can't run multiple instances of webview without specifying new port

### DIFF
--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -150,7 +150,12 @@ def enable_convergence_kernel_heartbeat():
 
 def _create_socket():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+        # Windows
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+    else:
+        # Unix and MacOS
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     return sock
 
 


### PR DESCRIPTION
On windows, users starting more than one webview server instance without specifying a new --port would all end up trying to re-use the default port (5148) which breaks things.

In this PR, the socket is set up to use the option `socket.SO_EXCLUSIVEADDRUSE` instead of `socket.SO_REUSEADDR`, when that option is available (only on Windows)

Tested on Windows and Linux, that it does the correct thing after the change (starting multiple instances of the server first starts one on  port 5148, then subsequent starts use a random higher port)