### PR TITLE
improve dream resume support

### DIFF
--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -296,6 +296,7 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
             logp = dream.model.map(x)
             state._generation(new_draws=n_chain, x=x, logp=logp, accept=n_chain, force_keep=True)
             dream.monitor(state, x, logp)
+        # print(f"Initial pop has draws={state.draws} gen={state.generation} pop={dream.population.shape}")
 
     state._update(CR_weight=dream.CR.weight)
 
@@ -321,6 +322,7 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
     next_outlier_test = max(state.Ngen, 2 * state.Ngen - 10)
     next_convergence_test = state.Ngen
     final_gen = dream.draws + dream.burn
+    # print(f"running dream with {dream.draws} draws and {dream.burn} burn; final gen={final_gen} draws={state.draws} gen={state.generation}")
     while state.draws < final_gen:
         # Age the population using differential evolution
         dream.CR.reset()

--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -453,7 +453,7 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
             dream.CR.adapt()
 
         if False:
-            # Suppress scale update until we have a chance to verify that it
+            # TODO: Suppress scale update until we have a chance to verify that it
             # doesn't skew the resulting statistics.
             _, r = state.acceptance_rate()
             ravg = np.mean(r[-dream.DE_steps :])

--- a/bumps/dream/state.py
+++ b/bumps/dream/state.py
@@ -429,6 +429,11 @@ class MCMCDraw(object):
     title = None
 
     def __init__(self, Ngen: int, Nthin: int, Nupdate: int, Nvar: int, Npop: int, Ncr: int, thinning: int):
+        # self.generation and self.draws are used to control the number of iterations in
+        # the dream loop, and must therefore be set to the current size of the state on
+        # resume rather than the cumulative across all runs. To retrieve the totals use
+        # generations=self.total_generations and draws=self.total_generations*self.Npop.
+
         # Total number of draws so far
         self.draws = 0
 
@@ -548,7 +553,12 @@ class MCMCDraw(object):
             return v
 
         self._gen_offset += max(self.generation - Ngen, 0)
+        self.generation = min(self.generation, Ngen, self.Ngen)
+        self.draws = self.generation * self.Npop
+        self._gen_index = 0
+        # Reset sample size to current size on resume.
         self.generation = min(self.generation, self.Ngen, Ngen)
+        self.draws = self.generation * self.Npop
         self._gen_index = self.generation % Ngen
         self._gen_draws = buf_resize(self._gen_draws, Ngen, self.generation)
         self._gen_logp = buf_resize(self._gen_logp, Ngen, self.generation)

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -897,6 +897,7 @@ class DreamFit(FitBase):
             steps = (draws + pop_size - 1) // pop_size
         monitors.info(f"# burn: {options['burn']} # steps: {steps}, # draws: {pop_size * steps}")
         population = population[None, :, :]
+        # print(f"Running dream with {population.shape=} {pop_size=} {steps=}")
         sampler = Dream(
             model=DreamModel(self.problem, mapper),
             population=population,

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -494,6 +494,7 @@ def get_max_steps(num_fitparams: int, fitter_id: str, options: Dict[str, Any]):
     options = {**dict(fitter.settings), **dict(options)}
     steps = options["steps"]  # all fitters have "steps"
     starts = options.get("starts", 1)  # Multistart fitter
+    # TODO: Max steps is wrong for DE with resume. Instead let the fitter tell the step monitor how many steps.
     if fitter_id == "dream":  # Dream has steps + burn
         if steps == 0:  # Steps not specified; using samples instead
             pop, draws = options["pop"], options["samples"]
@@ -608,7 +609,7 @@ async def start_fit_thread(fitter_id: str, options: Optional[Dict[str, Any]] = N
         uncertainty_update=state.shared.autosave_session_interval,
         console_update=state.console_update_interval,
         fit_state=state.fitting.fit_state,
-        # TODO: on resume should we pass the current convergence vector?
+        convergence=state.fitting.convergence,
     )
 
     await log(

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -507,7 +507,9 @@ class State:
         """
         if copy:
             self.fitting = deepcopy(self.fitting)
+            # print(f"reset_fitstate {copy}: keeping {self.fitting.method} with {self.fitting.fit_state} and convergence={self.fitting.convergence is not None}")
         else:
+            # print(f"reset_fitstate {copy}: keeping {self.fitting.method}")
             self.fitting = FitResult(
                 method=self.shared.selected_fitter,
                 options=self.shared.fitter_settings[self.shared.selected_fitter]["settings"],
@@ -517,6 +519,7 @@ class State:
         self.shared.active_history = None
 
     def set_convergence(self, convergence):
+        # print("setting convergence", convergence is not None)
         self.fitting.convergence = convergence
         self.shared.updated_convergence = now_string()
         self.shared.convergence_available = convergence is not None

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -77,8 +77,12 @@ def init_web_app():
 
         @routes.get(f"/{fn.__name__}")
         async def handler(request: web.Request):
-            result = await fn(**request.query)
-            return web.json_response(result)
+            try:
+                result = await fn(**request.query)
+                return web.json_response(result)
+            except Exception as err:
+                logger.exception(err)
+                raise
 
         # pass the function to the next decorator unchanged...
         return fn
@@ -92,7 +96,12 @@ def init_web_app():
 
         @functools.wraps(function)
         async def with_sid(sid: str, *args, **kwargs):
-            return await function(*args, **kwargs)
+            try:
+                # print("RPC:", function.__name__, args, kwargs)
+                return await function(*args, **kwargs)
+            except Exception as err:
+                logger.error(f"Exception for {function.__name__}(*{args}, **{kwargs}): {err}")
+                raise
 
         return with_sid
 


### PR DESCRIPTION
See #260

Fixes convergence test for --alpha in dream (the test was reversed).

Improves error reporting for webserver RPC calls.

Preserves total number of generations.

Note: DE reports wrong number of steps on resume, but that will be posted as a separate ticket.