### PR TITLE
Remove fixed and fittable attributes from ValueProtocol.

### DIFF
--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -518,7 +518,6 @@ class Parameter(ValueProtocol, SupportsPrior):
     def __repr__(self):
         return "Parameter(%s)" % self
 
-    # TODO: deprecate
     @classmethod
     def default(cls: type, value: Union[float, Tuple[float, float], ValueType], **kw) -> "Parameter":
         """

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -145,14 +145,8 @@ class ValueProtocol(OperatorMixin):
     Provide a suite of operators for creating parameter expressions.
     """
 
-    fittable: bool = False
-    fixed: bool = True
     value: float
 
-    # TODO: Do values have names? Or do the names belong to the model parameter?
-    # name: str
-    # TODO: are priors on the parameter or on the value?
-    # bounds: Optional[BoundsType] = None
     def parameters(self) -> List["Parameter"]:
         # default implementation:
         return []
@@ -469,18 +463,6 @@ class Parameter(ValueProtocol, SupportsPrior):
             self._fixed = state
         elif not state:
             raise TypeError(f"value in {self.name} is not fittable")
-
-    ## Use the following if bounds are on the value rather than the parameter
-    # @property
-    # def bounds(self):
-    #    return getattr(self.slot, 'bounds', None)
-    # @bounds.setter
-    # def bounds(self, b):
-    #    if not hasattr(self.slot, 'bounds'):
-    #        raise TypeError(f"{self.name} is not fittable so bounds can't be set")
-    #    if self.slot.fittable:
-    #        self.slot.fixed = (b is None)
-    #    self.slot.bounds = b
 
     # Functional form of parameter value access
     def __call__(self):

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -324,7 +324,6 @@ class Parameter(ValueProtocol, SupportsPrior):
     # prior: Optional[BoundsType]
     id: str = field(metadata={"format": "uuid"})
     name: Optional[str] = field(default=None, init=False)
-    fixed: bool = True
     slot: Union["Variable", ValueType]
     limits: Tuple[Union[float, Literal["-inf"]], Union[float, Literal["inf"]]] = (-inf, inf)
     bounds: Optional[Tuple[Union[float, Literal["-inf"]], Union[float, Literal["inf"]]]] = None
@@ -719,9 +718,6 @@ class Constant(ValueProtocol):  # type: ignore
     name: Optional[str] = None
     id: str = field(metadata={"format": "uuid"}, default_factory=lambda: str(uuid.uuid4()))
 
-    fittable = False  # class property fixed across all objects
-    fixed = True  # class property fixed across all objects
-
     def parameters(self):
         return [self]
 
@@ -860,9 +856,6 @@ class Expression(ValueProtocol):
     """
     Parameter expression
     """
-
-    fittable = False
-    fixed = True
 
     op: Union[Operators, "UserFunction"]  # Enumerated str type {function_name: display_name}
     args: Sequence[ValueType]
@@ -1562,8 +1555,6 @@ class Comparisons(Enum):
 @dataclass(init=False)
 class Constraint:
     """Express inequality constraints between model elements"""
-
-    fixed = True
 
     op: Comparisons
     a: ValueType

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -325,6 +325,7 @@ class Parameter(ValueProtocol, SupportsPrior):
     id: str = field(metadata={"format": "uuid"})
     name: Optional[str] = field(default=None, init=False)
     slot: Union["Variable", ValueType]
+    fixed: bool = True  # Adds "fixed" to __annotations__ so that @dataclass can find it.
     limits: Tuple[Union[float, Literal["-inf"]], Union[float, Literal["inf"]]] = (-inf, inf)
     bounds: Optional[Tuple[Union[float, Literal["-inf"]], Union[float, Literal["inf"]]]] = None
     distribution: DistributionType = field(default_factory=Uniform)


### PR DESCRIPTION
slot.fixed and slot.fittable are never used. Remove them from ValueProtocol and its subclasses.