### PR TITLE
add a helper function to simplify usage of Calculation in models

### DIFF
--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -550,6 +550,21 @@ class Parameter(ValueProtocol, SupportsPrior):
         else:
             return cls(value, **kw)
 
+    @staticmethod
+    def initialize_calculation(obj: Optional["Parameter"], name: str, function: Callable[[], float]) -> "Parameter":
+        """
+        If obj is a Parameter, use it - otherwise create a new Parameter obj with the given name.
+
+        Then create a Calculation object and attach the evaluator function to the Calculation,
+        and put the Calculation in obj.slot
+
+        Returns obj: Parameter
+        """
+        if not isinstance(obj, Parameter):
+            obj = Parameter(name=name)
+        obj.slot = Calculation(function=function)
+        return obj
+
     def set(self, value):
         """
         Set a new value for the parameter, ignoring the bounds.

--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -551,8 +551,16 @@ class Parameter(ValueProtocol, SupportsPrior):
             return cls(value, **kw)
 
     @staticmethod
-    def initialize_calculation(obj: Optional["Parameter"], name: str, function: Callable[[], float]) -> "Parameter":
+    def calculation(obj: Optional["Parameter"], name: str, function: Callable[[], float]) -> "Parameter":
         """
+        Create a parameter to hold a value derived from the model. This can be used in
+        parameter expressions, for example to constrain total thickness or to set the
+        value in the next segment equal to the value at the end of a freeform segment.
+
+        Note that this function should be called in the __init__ or __post_init__ methods of
+        the class where the parameter is defined, in order to bind the Calculation function
+        to the newly created (or deserialized) Parameter before it is used.
+
         If obj is a Parameter, use it - otherwise create a new Parameter obj with the given name.
 
         Then create a Calculation object and attach the evaluator function to the Calculation,


### PR DESCRIPTION
Example usage, in a class where `thickness` is a calculated value:

```python
@dataclass(init=False)
class Stack(Layer):
    """
    Reflectometry layer stack

    A reflectometry sample is defined by a stack of layers. Each layer
    has an interface describing how the top of the layer interacts with
    the bottom of the overlaying layer. The stack may contain
    """

    name: str
    interface: Literal[None]
    layers: List[Union["Slab", "Repeat"]]
    thickness: Parameter = field(metadata={"description": "always equals the sum of the layer thicknesses"})

    def __init__(
        self,
        layers: Optional[Union["Stack", List[Union["Slab", "Repeat"]]]] = None,
        name: str = "Stack",
        interface=None,
        thickness: Optional[Parameter] = None,
    ):
        self.name = name
        self.interface = None
        self._layers = []
        # make sure thickness.id is persistent through serialization:
        self.thickness = Parameter.initialize_calculation(thickness, name=name + " thickness", function=self._calculate_thickness)
        if layers is not None:
            self.add(layers)
```