### PR TITLE
Use float32 for uncertainty state storage instead of float64

### DIFF
--- a/bumps/dream/state.py
+++ b/bumps/dream/state.py
@@ -110,7 +110,7 @@ CREATE = gzip.open
 SelectionType = Optional[Dict[Union[int, Literal["logp"]], Tuple[float, float]]]
 
 
-UNCERTAINTY_DTYPE = "d"
+UNCERTAINTY_DTYPE = "f"
 MAX_LABEL_LENGTH = 1024
 LABEL_DTYPE = f"|S{MAX_LABEL_LENGTH}"
 H5_COMPRESSION = 5


### PR DESCRIPTION
This is a one-character PR, mostly here to invite discussion:

We can get much smaller stored versions of the dream state if we store them as float32 than float64, because in most cases for the models we're using we're not very sensitive to the extra precision, and in a random sampling scheme (like dream) the extra bytes are most likely uncompressible noise.

This translates into much better compression for float32. (worth collecting some numbers here)