### PR TITLE
Entry points plugins

### DIFF
--- a/bumps/gui/gui_app.py
+++ b/bumps/gui/gui_app.py
@@ -271,7 +271,9 @@ class MainApp(wx.App):
         # Put up the initial model
         model, output = initial_model(opts)
         if not model:
-            model = plugin.new_model()
+            plugin_new_model_fn = plugin.NEW_MODEL_PLUGINS.get(plugin.ACTIVE_PLUGIN_NAME, None)
+            if plugin_new_model_fn is not None:
+                model = plugin_new_model_fn()
         signal.log_message(message=output)
         self.frame.panel.set_model(model=model)
         self.frame.panel.set_fit_config(opts.fit_config)


### PR DESCRIPTION
Currently, in order to introduce app-specific functionality a number of methods are placed in `bumps.plugin`, which are then (at least partially) partially replaced when `bumps.cli.install_plugin(new_plugin_module)` is run, prior to starting e.g. the `refl1d` wx GUI.

In this PR a new method of introducing plugin functionality is used, leveraging `importlib.metadata.entry_points()`

For each function previously overridden directly in the `bumps.plugin` module, instead we discover plugins by group name.  The currently used groups are:

- `bumps.serialization.migration`
- `bumps.model.load`
- `bumps.model.new`
- "bumps.errplot.matplotlib"
- "bumps.wx_gui.data_view"
- "bumps.wx_gui.data_view"
- "bumps.serialize.save_json"

In addition there is one global setting `bumps.plugin.ACTIVE_PLUGIN_NAME`, which an application can change.

For example, in the old scheme the wx GUI would set the "Data" panel to the class returned by `plugin.data_view()`, which by default returns `bumps.gui.data_view.DataView`, but in `refl1d.bumps_interface.fitplugin`, it is overriden so that `data_view()` returns `refl1d.wx_gui.data_view.DataView`.

In the new scheme, we register an entry point for data views like this, in `refl1d/pyproject.toml` _(result will have group name "bumps.wx_gui.data_view" and name "refl1d")_
```toml
[project.entry-points."bumps.wx_gui.data_view"]
refl1d = "refl1d.wx_gui.data_view:DataView"
```

Then in the wx GUI code for bumps, when it is creating the panels it gets the plugin version with this code (falling back to `bumps.gui.data_view.DataView`):
```python
self.view_constructor = {
    "data": plugin.DATA_VIEW_PLUGINS.get(plugin.ACTIVE_PLUGIN_NAME, DataView),
    ...
}
```

Note that this requires that we set `bumps.plugin.ACTIVE_PLUGIN_NAME = "refl1d"` before starting the wx GUI.

## Serialization migrations
A benefit of this scheme is that migrations can be discovered rather than requiring libraries to actively register them with bumps before use.

Now, the deserializer discovers all migration functions and applies them by default, so no refl1d imports are required when loading a refl1d JSON model with the bumps loader, e.g.
```python
from bumps.serialize import load_file

problem = load_file("./my_refl1d_problem.json")
```
even for older serialized models as the refl1d migrations are automatically applied.

