### PR TITLE
Fix logic for automatic burn point determination

### DIFF
--- a/bumps/dream/convergence.py
+++ b/bumps/dream/convergence.py
@@ -166,13 +166,14 @@ def burn_point(state, method="window", trials=TRIALS, **kwargs):
     return index
 
 
-def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01, samples=SAMPLES):
+def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA, samples=SAMPLES):
     _, logp = state.logp()
 
     window_size = min(max(samples // state.Npop + 1, MIN_WINDOW), state.Ngen // 2)
     tiny_window = window_size // 11 + 1
     half = state.Ngen // 2
     max_index = len(logp) - half - window_size
+    # print("max index", max_index, "window size", window_size, "half", half, "Ngen", state.Ngen, "len(logp)", len(logp))
 
     if max_index < 0:
         return -1
@@ -195,14 +196,12 @@ def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01
             continue
 
         # if head and tail are different, slide to the next window
-        reject = _robust_ks_2samp(window, tail, n_draw, trials, alpha)
-        if reject:
-            continue
-
-        # Head and tail are not significantly different, so break.
-        # Index is not yet updated, so the tiny step loop will start with
-        # the first rejected window.
-        break
+        # p_val represents the probability that the two samples are from the same distribution.
+        p_val = _robust_ks_2samp(window, tail, n_draw, trials)
+        # print("ks", index, window_size, len(window), p_val, alpha)
+        if p_val >= alpha:
+            # two samples look the same, so we do not reject the null hypothesis.
+            break
 
     if index >= max_index:
         return -1
@@ -214,10 +213,10 @@ def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01
             # print("tiny llf", index, tiny_window, len(window), np.min(window), min_tail)
             continue
 
-        p_val = _robust_ks_2samp(window, tail, n_draw, trials, alpha)
+        p_val = _robust_ks_2samp(window, tail, n_draw, trials)
         # print("tiny ks", index, tiny_window, len(window), p_val, alpha)
-        if p_val > alpha:
-            # head and tail are not significantly different, so break
+        if p_val >= alpha:
+            # head and tail are not significantly different, so stop
             break
 
     return index

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -869,7 +869,7 @@ class DreamFit(FitBase):
         ("thin", 1),
         ("alpha", 0.0),
         ("outliers", "none"),
-        ("trim", False),
+        # ("trim", False),
         ("steps", 0),  # deprecated: use --samples instead
     ]
 
@@ -913,7 +913,7 @@ class DreamFit(FitBase):
         self.state = sampler.sample(state=self.state, abort_test=monitors.stopping)
         # print("<<< Dream is done sampling >>>")
 
-        self._trimmed = self.state.trim_portion() if options["trim"] else 1.0
+        self._trimmed = self.state.trim_portion() if options.get("trim", False) else 1.0
         # print("trimming", options['trim'], self._trimmed)
         self.state.mark_outliers(portion=self._trimmed)
         self.state.keep_best()


### PR DESCRIPTION
When `--trim` is enabled as a fit option, DreamFit will try to determine an automatic "burn point" with a sliding-window test similar to the alpha convergence test.

The logic for this test was broken in some recent refactoring, this PR fixes the logic.

At the same time, the `--trim` option is removed from the interface right now because although this PR fixes the logic for finding an automatic burn point, that point is not stored in the fit_state and so is not available at the time plots are generated, so enabling `trim` has no effect on the export output or any of the webview plots.