### PR TITLE
Store user-controlled 'portion' setting in Dream state

### DIFF
--- a/bumps/dream/convergence.py
+++ b/bumps/dream/convergence.py
@@ -10,6 +10,7 @@ the log probabilities are still improving throughout the chain.
 __all__ = ["burn_point", "ks_converged"]
 
 from typing import TYPE_CHECKING
+import warnings
 
 import numpy as np
 from numpy.random import choice
@@ -161,8 +162,9 @@ def burn_point(state, method="window", trials=TRIALS, **kwargs):
         index = _ks_sliding_window(state, trials=trials, **kwargs)
     else:
         raise ValueError("Unknown convergence test " + method)
+    # TODO: need a better way to report convergence failure
     if index < 0:
-        print("Did not converge!")
+        warnings.warn("Did not converge!")
     return index
 
 

--- a/bumps/dream/convergence.py
+++ b/bumps/dream/convergence.py
@@ -166,13 +166,14 @@ def burn_point(state, method="window", trials=TRIALS, **kwargs):
     return index
 
 
-def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01, samples=SAMPLES):
+def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA, samples=SAMPLES):
     _, logp = state.logp()
 
     window_size = min(max(samples // state.Npop + 1, MIN_WINDOW), state.Ngen // 2)
     tiny_window = window_size // 11 + 1
     half = state.Ngen // 2
     max_index = len(logp) - half - window_size
+    # print("max index", max_index, "window size", window_size, "half", half, "Ngen", state.Ngen, "len(logp)", len(logp))
 
     if max_index < 0:
         return -1
@@ -195,14 +196,12 @@ def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01
             continue
 
         # if head and tail are different, slide to the next window
-        reject = _robust_ks_2samp(window, tail, n_draw, trials, alpha)
-        if reject:
-            continue
-
-        # Head and tail are not significantly different, so break.
-        # Index is not yet updated, so the tiny step loop will start with
-        # the first rejected window.
-        break
+        # p_val represents the probability that the two samples are from the same distribution.
+        p_val = _robust_ks_2samp(window, tail, n_draw, trials)
+        # print("ks", index, window_size, len(window), p_val, alpha)
+        if p_val >= alpha:
+            # two samples look the same, so we do not reject the null hypothesis.
+            break
 
     if index >= max_index:
         return -1
@@ -214,10 +213,10 @@ def _ks_sliding_window(state, trials=TRIALS, density=DENSITY, alpha=ALPHA * 0.01
             # print("tiny llf", index, tiny_window, len(window), np.min(window), min_tail)
             continue
 
-        p_val = _robust_ks_2samp(window, tail, n_draw, trials, alpha)
+        p_val = _robust_ks_2samp(window, tail, n_draw, trials)
         # print("tiny ks", index, tiny_window, len(window), p_val, alpha)
-        if p_val > alpha:
-            # head and tail are not significantly different, so break
+        if p_val >= alpha:
+            # head and tail are not significantly different, so stop
             break
 
     return index

--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -284,6 +284,9 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
     # Record initial state
     allocate_state(dream)
     state = dream.state
+    # Reset plot portion to 100% during fitting so that the intermediate plots show the
+    # full set of samples.
+    state.portion = 1.0
     state.labels = dream.model.labels
     previous_draws = state.draws
     if previous_draws:

--- a/bumps/dream/state.py
+++ b/bumps/dream/state.py
@@ -596,8 +596,6 @@ class MCMCDraw(object):
     def show(self, portion: Optional[float] = None, figfile: Union[str, Path, None] = None):
         from .views import plot_all
 
-        # use the stored portion if not specified
-        portion = self.portion if portion is None else portion
         plot_all(self, portion=portion, figfile=figfile)
 
     def _last_gen(self):
@@ -824,11 +822,11 @@ class MCMCDraw(object):
         """
         _, chains, logp = self.chains()
 
-        portion = self.portion if portion is None else portion
         if test == "none":
             self._good_chains = slice(None, None)
         else:
             Ngen = chains.shape[0]
+            portion = self.portion if portion is None else portion
             start = int(Ngen * (1 - portion))
             outliers = identify_outliers(test, logp[start:], chains[-1])
             # print("outliers", outliers)
@@ -960,15 +958,15 @@ class MCMCDraw(object):
             retval = [v[: self._thin_count] for v in retval]
         return retval
 
-    def gelman(self):
+    def gelman(self, portion: Optional[float] = None):
         """
-        Compute the R-statistic for the current frame
+        Compute the Gelman and Rubin R-statistic for the Markov chains.
         """
-        # Calculate Gelman and Rubin convergence diagnostic
+        portion = self.portion if portion is None else portion
         if self.generation < self.Ngen:
-            return gelman(self._thin_point[: self.generation], portion=1.0)
+            return gelman(self._thin_point[: self.generation], portion=portion)
         else:
-            return gelman(self._thin_point, portion=1.0)
+            return gelman(self._thin_point, portion=portion)
 
     def CR_weight(self):
         """
@@ -1116,7 +1114,6 @@ class MCMCDraw(object):
         """
         from . import entropy
 
-        portion = self.portion if portion is None else portion
         # Get the sample from the state.
         # set default thinning to max((steps * samples/step) // n_est, 1)
         if thin is None:

--- a/bumps/dream/views.py
+++ b/bumps/dream/views.py
@@ -22,9 +22,7 @@ def plot_all(state: MCMCDraw, portion: Optional[float] = None, figfile=None):
     all_vstats = var_stats(draw)
     print(format_vars(all_vstats))
     print(
-        "\nStatistics and plots based on {nsamp:d} samples ({psamp:.1%} of total samples drawn)".format(
-            nsamp=len(draw.points), psamp=draw.portion
-        )
+        f"\nStatistics and plots based on {len(draw.points)} samples ({int(100*draw.portion)}% of total samples drawn)"
     )
     if figfile is not None:
         save_vars(all_vstats, figfile + "-err.json")
@@ -188,13 +186,14 @@ def plot_trace(state: MCMCDraw, var: int = 0, portion: Optional[float] = None, a
     axes.set_ylabel(label)
 
 
-def plot_logp(state: MCMCDraw, portion: float = 1.0):
+def plot_logp(state: MCMCDraw, portion: Optional[float] = None):
     from matplotlib.ticker import NullFormatter
     from pylab import axes, title
     from scipy.stats import chi2, kstest
 
     # Plot log likelihoods
     draw, logp = state.logp()
+    portion = state.portion if portion is None else portion
     start = int((1 - portion) * len(draw))
     genid = arange(state.generation - len(draw) + start, state.generation) + 1
     width, height, margin, delta = 0.7, 0.75, 0.1, 0.01
@@ -277,8 +276,8 @@ def tile_axes(n, size=None, fig=None):
 def plot_acceptance_rate(state: MCMCDraw, portion: Optional[float] = None):
     from matplotlib import pyplot as plt
 
-    portion = state.portion if portion is None else portion
     gen, AR = state.acceptance_rate()
+    portion = state.portion if portion is None else portion
     if portion != 1.0:
         index = int(portion * len(AR))
         gen, AR = gen[-index:], AR[-index:]

--- a/bumps/errplot.py
+++ b/bumps/errplot.py
@@ -44,6 +44,7 @@ __all__ = ["reload_errors", "calc_errors_from_state", "calc_errors", "show_error
 import os
 import traceback
 import logging
+from typing import Optional
 
 import numpy as np
 
@@ -75,7 +76,7 @@ def reload_errors(model, store, nshown=50, random=True):
     return calc_errors_from_state(problem, state, nshown=nshown, random=random)
 
 
-def error_points_from_state(state, nshown=50, random=True, portion=1.0):
+def error_points_from_state(state, nshown=50, random=True, portion: Optional[float] = None):
     """
     Return a set of points from the state for calculating errors.
 
@@ -100,7 +101,7 @@ def error_points_from_state(state, nshown=50, random=True, portion=1.0):
     return points[-nshown:-1]
 
 
-def calc_errors_from_state(problem, state, nshown=50, random=True, portion=1.0):
+def calc_errors_from_state(problem, state, nshown=50, random=True, portion: Optional[float] = None):
     """
     Compute confidence regions for a problem from the
     Align the sample profiles and compute the residual difference from

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -913,7 +913,8 @@ class DreamFit(FitBase):
         self.state = sampler.sample(state=self.state, abort_test=monitors.stopping)
         # print("<<< Dream is done sampling >>>")
 
-        # if "trim" option is enabled, automatically set the portion
+        # If "trim" option is enabled, automatically set the portion, otherwise use
+        # the default 100% that was set at the start of sampler.sample.
         if options.get("trim", False):
             self.state.portion = self.state.trim_portion()
         # print("trimming", options['trim'], self._trimmed)

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1115,10 +1115,9 @@ async def get_parameter_trace_plot(var: int):
         logger.info(f"queueing new parameter_trace plot... {start_time}")
 
         # begin plotting:
-        portion = None
         draw, points, _ = fit_state.chains()
         label = fit_state.labels[var]
-        start = int((1 - portion) * len(draw)) if portion else 0
+        start = int((1 - fit_state.portion) * len(draw))
         genid = (
             np.arange(
                 fit_state.generation - len(draw) + start,


### PR DESCRIPTION
Instead of generating an ephemeral private `._trimmed` attribute on the fitter class when the `trim` option is enabled, store the calculated portion in a new attribute `portion` on the Dream state.

Then this `portion` is used by default in the various dream plots and other outputs.

It is a public attribute of the Dream state because the user may wish to set it manually as well, e.g. in a GUI. 

The stored portion is also used by default in any `state.draw()` unless a float (non-None) `portion` kwarg is supplied e.g. `state.draw(portion=0.5...)`