### PR TITLE
Fix method for starting webview server in jupyter

### DIFF
--- a/bumps/webview/server/__init__.py
+++ b/bumps/webview/server/__init__.py
@@ -1,0 +1,1 @@
+from .webserver import start_bumps_server

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -299,8 +299,8 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
 @register
 async def set_session_output_file(filepath: Optional[Union[str, Path]] = None):
     """
-    Set the session output file to be used for saving results.
-    If `filepath` is None, the session output file is cleared.
+    Set the session output file to be used for saving results, and enable autosave.
+    If `filepath` is None, the session output file is cleared and autosave is disabled.
     """
     if filepath is None:
         await state.shared.set("session_output_file", None)

--- a/bumps/webview/server/names.py
+++ b/bumps/webview/server/names.py
@@ -1,3 +1,3 @@
 # TODO: is this being used anywhere?
 from .api import state, set_problem, load_session
-from .webserver import start_app, create_server_task
+from .webserver import start_app, start_bumps_server

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -259,11 +259,12 @@ def start_from_cli(options: BumpsOptions):
 server_task = None
 
 
-def bumps_server():
+def start_jupyter_server():
     global server_task
 
     # Start the server
-    server_task = asyncio.create_task(start_app(jupyter_link=True))
+    options = BumpsOptions()
+    server_task = asyncio.create_task(start_app(options, jupyter_link=True))
     return server_task
 
 

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -256,15 +256,14 @@ def start_from_cli(options: BumpsOptions):
     web.run_app(app, sock=runsock)
 
 
-server_task = None
-
-
 def start_bumps_server():
-    global server_task
-
-    # Start the server
-    server_task = asyncio.create_task(start_app(jupyter_link=True))
-    return server_task
+    """
+    Start the webview server in a background asyncio.Task,
+    and show the link to the webview in a Jupyter notebook.
+    Note that the returned Task should be awaited in order
+    to handle any exceptions that may occur during startup.
+    """
+    return asyncio.create_task(start_app(jupyter_link=True))
 
 
 async def start_app(

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -259,7 +259,7 @@ def start_from_cli(options: BumpsOptions):
 server_task = None
 
 
-def bumps_server():
+def start_bumps_server():
     global server_task
 
     # Start the server
@@ -298,10 +298,6 @@ async def start_app(
     else:
         url = get_server_url()
         print(f"webserver started: {url}")
-
-
-def create_server_task():
-    return asyncio.create_task(start_app())
 
 
 def get_server_url():

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -259,17 +259,16 @@ def start_from_cli(options: BumpsOptions):
 server_task = None
 
 
-def start_jupyter_server():
+def bumps_server():
     global server_task
 
     # Start the server
-    options = BumpsOptions()
-    server_task = asyncio.create_task(start_app(options, jupyter_link=True))
+    server_task = asyncio.create_task(start_app(jupyter_link=True))
     return server_task
 
 
 async def start_app(
-    options: BumpsOptions,
+    options: BumpsOptions = None,
     sock: socket.socket = None,
     jupyter_link: bool = False,
     jupyter_heartbeat: bool = False,
@@ -277,6 +276,8 @@ async def start_app(
     from aiohttp import web
 
     init_web_app()
+    if options is None:
+        options = BumpsOptions()
 
     # this function is called from jupyter notebook, so set headless = True
     options.headless = True


### PR DESCRIPTION
This PR adds a method with the same name as the new one provided in refl1d PR 299 for starting a webview server within a jupyter notebook: `start_jupyter_server`

This method automatically enables the webview link display on server start (the option `jupyter_link=True` is passed to `start_app`), and it returns an asyncio task that should be awaited in the notebook, in order to capture any exceptions that are raised during the server start, e.g.
```python
from bumps.webview.server.webserver import start_jupyter_server

await start_jupyter_server()
```