### PR TITLE
Install webview dependencies by default

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -94,12 +94,6 @@ jobs:
         run: |
           uv venv
           find dist -name "bumps-*-py3-none-any.whl" -exec uv pip install {}[dev] \;
-      - name: Run tests, except for webview
-        run: uv run python -m pytest -v --ignore=bumps/webview
-
-      - name: Install dependencies for webview testing
-        run: find dist -name "bumps-*-py3-none-any.whl" -exec uv pip install {} \;
-
       - name: Run tests
         run: uv run python -m pytest -v
 

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -98,7 +98,7 @@ jobs:
         run: uv run python -m pytest -v --ignore=bumps/webview
 
       - name: Install dependencies for webview testing
-        run: find dist -name "bumps-*-py3-none-any.whl" -exec uv pip install {}[webview] \;
+        run: find dist -name "bumps-*-py3-none-any.whl" -exec uv pip install {} \;
 
       - name: Run tests
         run: uv run python -m pytest -v

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           uv venv
           find dist -name "bumps-*-py3-none-any.whl" -exec uv pip install {}[dev] \;
+
       - name: Run tests
         run: uv run python -m pytest -v
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ the uncertainty around the minimum.
 
 Installation is with the usual python installation command::
 
-    pip install bumps[webview]
+    pip install bumps
 
 Once the system is installed, you can verify that it is working with::
 

--- a/doc/getting_started/install.rst
+++ b/doc/getting_started/install.rst
@@ -52,7 +52,7 @@ To create your environment and install bumps use::
 
     conda create --name bumps python
     conda activate bumps
-    pip install bumps[webview]
+    pip install bumps
 
 You could instead download Python directly from
 `Python.org <https://www.python.org/downloads/>`_.
@@ -60,7 +60,7 @@ Again, recommended practice is to use an isolated python environment::
 
     python -m venv bumps
     . bumps/bin/activate
-    pip install bumps[webview]
+    pip install bumps
 
 Running bumps
 =============
@@ -103,7 +103,7 @@ it available::
 If running on colab or similar, then you can install bumps from within a
 notebook cell using pip:
 
-    %pip install bumps[webview]
+    %pip install bumps
 
 To start webview, use the following code cell::
 

--- a/extra/build_conda_packed.sh
+++ b/extra/build_conda_packed.sh
@@ -17,7 +17,7 @@ conda create -y -p "$ISOLATED_ENV" "python=${PYTHON_VERSION:-3.12}" "nodejs" "mi
 cd "$SCRIPT_DIR"
 conda activate "$ISOLATED_ENV"
 
-python -m pip install --no-input --no-compile "..[webview]"
+python -m pip install --no-input --no-compile ".."
 python -m "${PACKAGE_NAME:-bumps}.webview.build_client" --cleanup
 
 conda deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     'dill',
     'matplotlib',
     'blinker',
+    'aiohttp',
+    'python-socketio',
+    'plotly',
+    'mpld3',
     'graphlib_backport; python_version < "3.9"',
 ]
 classifiers = [
@@ -39,12 +43,6 @@ dev = [
     'setuptools',
     'sphinx',
     'versioningit',
-]
-webview = [
-    'aiohttp',
-    'python-socketio',
-    'plotly',
-    'mpld3',
 ]
 
 [project.urls]


### PR DESCRIPTION
Move all the dependencies from an extra "webview" group to the main dependencies in `pyproject.toml`