### PR TITLE
Fix script args for curvefit/poisson.py and test_functions/model.py

### DIFF
--- a/bumps/curve.py
+++ b/bumps/curve.py
@@ -521,6 +521,7 @@ def logfactorial(n):
     return result
 
 
+@dataclass(init=False, eq=False)
 class PoissonCurve(Curve):
     r"""
     Model a measurement with Poisson uncertainty.
@@ -528,10 +529,14 @@ class PoissonCurve(Curve):
     The nllf is calculated using Poisson probabilities, but the curve itself
     is displayed using the approximation that $\sigma_y \approx \sqrt(y)$.
 
+    Note that the *dy* argument is ignored. It is only present for deserialization
+    of the Curve base class.
+
     See :class:`Curve` for details.
     """
 
-    def __init__(self, fn, x, y, name="", **fnkw):
+    def __init__(self, fn, x, y, dy=None, name="", **fnkw):
+        # dy ignored. It is needed for dataclass deserialization
         dy = sqrt(y) + (y == 0) if y is not None else None
         Curve.__init__(self, fn, x, y, dy, name=name, **fnkw)
         self._logfacty = logfactorial(y) if y is not None else None

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -797,23 +797,109 @@ def load_problem(filename, options=None) -> FitProblem:
 
     Namespace for imports is `bumps.user`
     """
-    # Allow relative imports from the bumps model
-    namespace = "bumps.user"
-    basename = os.path.splitext(os.path.basename(filename))[0]
-    module = util.relative_import(filename, module_name=namespace)
+    import re
+    from pathlib import Path
+    from hashlib import md5
+    from importlib.machinery import SourceFileLoader
+    from importlib.util import module_from_spec, spec_from_loader
 
-    ctx = dict(__file__=filename, __package__=module, __name__=f"{namespace}.{basename}")
+    script_path = Path(filename).resolve()
+    if options is None:
+        options = ()
+
+    # Turn filename into a python identifier
+    name = script_path.stem.split(".", 1)[0]
+    name = "_".join(name.split())  # convert whitespace
+    name = re.sub(r"[^a-zA-Z0-9_]", "_", name)  # handle invalid characters
+    if name[0].isdigit():  # idnetifiers can't start with a digit
+        name = "_" + name
+
+    # Put all user scripts in the bumps.user namespace.
+    # They shouldn't conflict because they don't show up
+    # in sys.modules.
+    package = "bumps.user"
+
+    # Create the module for the script
+    fullname = f"{package}.{name}"
+    loader = SourceFileLoader(fullname, str(script_path))
+    spec = spec_from_loader(fullname, loader)
+    module = module_from_spec(spec)
+
+    # Execute the script
+    # TODO: Enable relative imports with ScriptFinder
     old_argv = sys.argv
-    sys.argv = [filename] + options if options else [filename]
-    source = open(filename).read()
-    code = compile(source, filename, "exec")
-    exec(code, ctx)
-    sys.argv = old_argv
-    problem = ctx.get("problem", None)
+    old_bytecode = sys.dont_write_bytecode
+    # meta_path_finder = ScriptFinder(script_path.parent, package)
+    try:
+        # sys.meta_path.insert(0, meta_path_finder)
+        sys.argv = [filename, *options]
+        sys.dont_write_bytecode = True  # Suppress .pyc creation
+        loader.exec_module(module)
+    finally:
+        # sys.meta_path.pop(0)
+        sys.argv = old_argv
+        sys.dont_write_bytecode = old_bytecode
+
+    problem = getattr(module, "problem", None)
     if problem is None:
         raise ValueError(filename + " requires 'problem = FitProblem(...)'")
 
+    # # Capture the source code and any dependent libraries. On deserialize we
+    # # will need to preload the libs and stuff them in sys.modules before
+    # # calling dill. Be sure to remove them immediately so that the next load
+    # # from script will get the latest version (the user may have changed the
+    # # support libraries without having changed the script).
+    # # Note that we won't be able to rerun the script because we aren't capturing
+    # # the original datafiles, but we may want to show it to the user.
+    # script = script_path.read_text()
+    # context = dict(script=script, libs=meta_path_finder.sources, options=options)
+
     return problem
+
+
+# Note: Not currently used
+class ScriptFinder:
+    """
+    sys.meta_path finder allowing relative imports in scripts.
+
+    *script_dir* is the parent directory for the script file.
+
+    *package_name* is the module namespace for the script.
+
+    *sources* contains {fullname: source_code} for all the supporting
+    modules in the script directory. Use these to deserialize the
+    saved problem.
+    """
+
+    def __init__(self, script_dir, package_name):
+        from importlib.machinery import ModuleSpec
+
+        self._path = script_dir
+        self._package = package_name + "."
+        self._parent_spec = ModuleSpec(package_name, None, is_package=True)
+        self.sources = {}
+
+    def find_spec(self, fullname, path, target=None):
+        from importlib.machinery import SourceFileLoader
+        from importlib.util import spec_from_loader
+
+        if fullname == self._package[:-1]:
+            # print(f'import looking for {fullname}')
+            return self._parent_spec
+        if fullname.startswith(self._package):
+            # print(f'import looking for {fullname}')
+            module_name = fullname.split(".")[-1]
+            module_path = self._path / f"{module_name}.py"
+            if module_path.exists():
+                loader = SourceFileLoader(fullname, str(module_path))
+                spec = spec_from_loader(fullname, loader)
+                # It is inefficient to load this twice, but the import
+                # hook machinery is too complicated to capture the source
+                # when it is loaded. Similarly for suppressing the .pyc
+                # file creation.
+                self.sources[fullname] = module_path.read_text()
+                return spec
+        return None
 
 
 def MultiFitProblem(*args, **kwargs) -> FitProblem:

--- a/bumps/names.py
+++ b/bumps/names.py
@@ -46,4 +46,3 @@ from .pdfwrapper import PDF, VectorPDF, DirectProblem
 from .curve import Curve, PoissonCurve
 from .fitproblem import FitProblem, Fitness
 from .fitters import fit
-from .util import relative_import

--- a/bumps/pdfwrapper.py
+++ b/bumps/pdfwrapper.py
@@ -14,14 +14,17 @@ here as well.
 """
 
 import inspect
+from dataclasses import dataclass
+from typing import Callable
 
 import numpy as np
 
-from .parameter import Parameter
+from .parameter import Parameter, ValueProtocol
 from .fitproblem import Fitness
 from .bounds import init_bounds
 
 
+@dataclass(init=False, eq=False)
 class PDF:
     """
     Build a model from a function.
@@ -46,15 +49,22 @@ class PDF:
     given in the function.
     """
 
+    fn: Callable
+    name: str
+    plotter: Callable
+    dof: int
+    pars: dict[str, Parameter] = None  # Needs to be None initially for getattr/setattr to work
+
     has_residuals = False  # Don't have true residuals
 
-    def __init__(self, fn, name="", plot=None, dof=1, **kw):
+    def __init__(self, fn, name="", plotter=None, dof=1, pars=None, **kw):
         self.dof = dof
         # Make every name a parameter; initialize the parameters
         # with the default value if function is defined with keyword
         # initializers; override the initializers with any keyword
         # arguments specified in the fit function constructor.
         labels, vararg, varkw, values, *_ = inspect.getfullargspec(fn)
+
         if vararg or varkw:
             raise TypeError("Function cannot have *args or **kwargs in declaration")
         # Parameters default to zero
@@ -70,35 +80,50 @@ class PDF:
         init.update(kw)
 
         # Build parameters out of ranges and initial values
-        pars = dict((p, Parameter.default(init[p], name=name + p)) for p in labels)
-
-        # Make parameters accessible as model attributes
-        for k, v in pars.items():
-            if hasattr(self, k):
-                raise TypeError("Parameter cannot be named %s" % k)
-            setattr(self, k, v)
+        if pars is None:
+            pars = dict((p, Parameter.default(init[p], name=name + p)) for p in labels)
+        self.pars = pars
 
         # Remember the function, parameters, and number of parameters
-        self._function = fn
+        self.fn = fn
         self._labels = labels
-        self._plot = plot
+        self.plotter = plotter
         self.name = name if name else "PDF"
 
+    # Allow dot access to members of the parameter dictionary. Existing attributes
+    # of the object take precedence.
+    def __setattr__(self, key, value):
+        # print(f"setting {key}")
+        if self.pars and key in self.pars and key not in self.__dict__:
+            if not isinstance(value, ValueProtocol):
+                raise TypeError("Can only assign parameter or expression to a parameter slot")
+            self.__dict__["pars"][key] = value
+        else:
+            super().__setattr__(key, value)
+
+    def __getattr__(self, key):
+        # print(f"getting {key}")
+        if self.pars and key in self.pars:
+            return self.pars[key]
+        raise AttributeError(f"{type(self)!r} has no attribute {key!r}")
+
     def parameters(self):
-        # Note: need to refetch the pars from self in case the user assigned
-        # model.par = new_parameter after creating the model.
-        return dict((p, getattr(self, p)) for p in self._labels)
+        return self.pars
 
     parameters.__doc__ = Fitness.parameters.__doc__
 
     def nllf(self):
         kw = dict((p, getattr(self, p).value) for p in self._labels)
-        return self._function(**kw)
+        return self.fn(**kw)
 
     nllf.__doc__ = Fitness.__call__.__doc__
 
     def chisq(self):
         return 2 * self.nllf() / self.dof
+
+    def residuals(self):
+        # A fake residuals vector of length 1.
+        return np.sqrt([2 * self.nllf()])
 
     # chisq.__doc__ = Fitness.chisq.__doc__
 
@@ -110,9 +135,9 @@ class PDF:
     __call__ = chisq
 
     def plot(self, view=None):
-        if self._plot:
+        if self.plotter:
             kw = dict((p, getattr(self, p).value) for p in self._labels)
-            self._plot(view=view, **kw)
+            self.plotter(view=view, **kw)
 
     plot.__doc__ = Fitness.plot.__doc__
 

--- a/bumps/serialize.py
+++ b/bumps/serialize.py
@@ -210,10 +210,12 @@ def serialize(obj, use_refs=True, add_libraries=True):
             return str(obj) if np.isinf(obj) else obj
         elif isinstance(obj, int) or isinstance(obj, str) or obj is None:
             return obj
+        elif isinstance(obj, np.integer):
+            return int(obj)
         elif callable(obj):
             return serialize_function(obj)
         else:
-            raise ValueError("obj %s is not serializable" % str(obj))
+            raise ValueError(f"obj {str(obj)} of type {type(obj)} is not serializable")
 
     serialized = {"$schema": SCHEMA, "object": obj_to_dict(obj), REFERENCES_KEY: references}
 

--- a/bumps/util.py
+++ b/bumps/util.py
@@ -178,33 +178,6 @@ def kbhit():
         return sys.stdin in i
 
 
-class DynamicModule(types.ModuleType):
-    def __init__(self, path, name):
-        self.__path__ = [path]
-        self.__name__ = name
-        # In the bowels of importlib the parent spec attribute is used to
-        # avoid circular imports, but only if spec is not None. This behaviour
-        # was observed on python 3.11, and perhaps earlier.
-        self.__spec__ = None
-
-
-def relative_import(filename, module_name="relative_import"):
-    """
-    Define an empty module allowing relative imports from a script.
-
-    By setting :code:`__package__ = relative_import(__file__)` at the top of
-    your script file you can even run your model as a python script.  So long
-    as the script behaviour is isolated in :code:`if __name__ == "__main__":`
-    code block and :code:`problem = FitProblem(...)` is defined, the same model
-    can be used both within and outside of bumps.
-    """
-    path = os.path.dirname(os.path.abspath(filename))
-    if module_name in sys.modules and not isinstance(sys.modules[module_name], DynamicModule):
-        raise ImportError("relative import would override the existing module %s. Use another name" % module_name)
-    sys.modules[module_name] = DynamicModule(path, module_name)
-    return module_name
-
-
 class redirect_console(object):
     """
     Console output redirection context

--- a/doc/examples/test_functions/model.py
+++ b/doc/examples/test_functions/model.py
@@ -35,7 +35,7 @@ except Exception as exc:
 
 plotter = plot2d(nllf, range=(-10, 10))
 
-M = PDF(nllf, plot=plotter)
+M = PDF(nllf, plotter=plotter)
 
 for p in M.parameters().values():
     # TODO: really should pull value and range out of the bounds for the

--- a/doc/examples/test_functions/model.py
+++ b/doc/examples/test_functions/model.py
@@ -1,291 +1,41 @@
 """
+Test functions for optimizers.
 
-Surjanovic, S. & Bingham, D. (2013).
-Virtual Library of Simulation Experiments: Test Functions and Datasets.
-Retrieved April 18, 2016, from http://www.sfu.ca/~ssurjano.
+Note that model_lib.py needs to be on your python path to run these tests.
+
+Usage:
+
+    PYTHONPATH=. bumps model.py MODEL DIM
+
+where MODEL is one of:
+
+    ackley              gauss               rastrigin
+    beale               griewank            rosenbrock
+    cross_in_tray       laplace             sin_plus_quadratic
+
+and DIM is an integer. See model definitions in model_lib.py.
 """
 
-import inspect
-from functools import reduce, wraps
+import sys
+import numpy as np
 
-from numpy import cos, e, exp, linspace, log, log1p, meshgrid, pi, sin, sqrt
-from scipy.special import gammaln
-
+from model_lib import select_function, plot2d
 from bumps.names import *
 
 
-class ModelFunction(object):
-    _registered = {}  # class mutable containing list of registered functions
-
-    def __init__(self, f, xmin, fmin, bounds, dim):
-        self.name = f.__name__
-        self.xmin = xmin
-        self.fmin = fmin
-        self.bounds = bounds
-        self.dim = dim
-        self.f = f
-
-        # register the function in the list of available functions
-        ModelFunction._registered[self.name] = self
-
-    def __call__(self, x):
-        return self.f(x)
-
-    def fk(self, k, **kw):
-        """
-        Return a function with *k* arguments f(x, y, z1, z2, ..., zk-2)
-        """
-        wrapper = wraps(self.f)
-        if k == 1:
-            calculator = wrapper(lambda x: self.f((x,), **kw))
-        elif k == 2:
-            calculator = wrapper(lambda x, y: self.f((x, y), **kw))
-        else:
-            args = ",".join("x%d" % j for j in range(1, k + 1))
-            context = {"self": self, "kw": kw}
-            calculator = wrapper(eval("lambda %s: self.f((%s), **kw)" % (args, args), context))
-        return calculator
-
-    def fv(self, k, **kw):
-        """
-        Return a function with arguments f(v) for vector v.
-        """
-        wrapper = wraps(self.f)
-        calculator = wrapper(lambda x: self.f(x, **kw))
-        return calculator
-
-    @staticmethod
-    def lookup(name):
-        return ModelFunction._registered.get(name, None)
-
-    @staticmethod
-    def available():
-        return list(sorted(ModelFunction._registered.keys()))
-
-
-def select_function(argv, vector=True):
-    if len(sys.argv) == 0:
-        raise ValueError("no function provided")
-
-    model = ModelFunction.lookup(argv[0])
-    if model is None:
-        raise ValueError("unknown model %s" % model)
-
-    dim = int(argv[1]) if len(argv) > 1 else 2
-
-    return model.fv(dim) if vector else model.fk(dim)
-
-
-def fit_function(xmin=None, fmin=None, bounds=(-inf, inf), dim=None):
-    return lambda f: ModelFunction(f, xmin, fmin, bounds, dim)
-
-
-# ================ Model functions ====================
-
-
-def prod(L):
-    return reduce(lambda x, y: x * y, L, 1)
-
-
-@fit_function(fmin=0.0, xmin=0.0)
-def gauss(x):
-    """
-    Multivariate gaussian distribution
-    """
-    # mu, sigma = 100.0, 0.001
-    mu, sigma = 3.0, 2.0
-    # note: sqrt(det(Sigma)) = p log(sigma) since Sigma = sigma^2 eye(p)
-    # log_norm = 0.5*len(x)*log(2*pi*sigma**2)
-    log_norm = 0
-    return 0.5 * sum(((xi - mu) / sigma) ** 2 for xi in x) - log_norm
-
-
-@fit_function(fmin=0.0, xmin=0.0)
-def t(x):
-    """
-    Multivariate t distribution
-    """
-    mu, sigma, nu = 3.0, 1.0, 2
-    p = len(x)
-    S = sum(((xi - mu) / sigma) ** 2 for xi in x) / nu
-    # note: sqrt(det(Sigma)) = p log(sigma) since Sigma = sigma^2 eye(p)
-    log_norm = gammaln(0.5 * (nu + p)) - gammaln(0.5 * nu) - 0.5 * p * log(nu + pi) - p * log(sigma)
-    return (nu + p) / 2 * log1p(S) - log_norm
-
-
-@fit_function(fmin=0.0, xmin=3.0)
-def laplace(x):
-    """
-    Product of Laplace distributions, mu=3, b=0.1.
-    """
-    return sum(abs(xi - 3.0) / 0.1 for xi in x)
-
-
-@fit_function(fmin=0.0, xmin=3.0)
-def sin_plus_quadratic(x, c=3.0, d=2.0, m=5.0, h=2.0):
-    """
-    Sin + quadratic.  Multimodal with global minimum.
-
-    *c* is the center point where the function is minimized.
-
-    *d* is the distance between modes, one per dimension.
-
-    *h* is the sine wave amplitude, on per dimension, which controls
-    the height of the barrier between modes.
-
-    *m* is the curvature of the quadratic, one per dimension.
-    """
-    n = len(x)
-    if np.isscalar(c):
-        c = [c] * n
-    if np.isscalar(d):
-        d = [d] * n
-    if np.isscalar(h):
-        h = [h] * n
-    if np.isscalar(m):
-        m = [m] * n
-    return sum(hi * (sin((2 * pi / di) * xi - ci) + 1.0) for xi, ci, di, hi in zip(x, c, d, h)) + sum(
-        ((xi - ci) / float(mi)) ** 2 for xi, ci, mi in zip(x, c, m)
-    )
-
-
-@fit_function(fmin=0.0, xmin=0.0)
-def stepped_well(x):
-    return sum(np.floor(abs(xi)) for xi in x)
-
-
-@fit_function(xmin=0.0, fmin=0.0, bounds=(-32.768, 32.768))
-def ackley(x, a=20.0, b=0.2, c=2 * pi):
-    """
-    Multimodal with deep global minimum.
-    """
-    n = len(x)
-    return -a * exp(-b * sqrt(sum(xi**2 for xi in x) / n)) - exp(sum(cos(c * xi) for xi in x) / n) + a + e
-
-
-@fit_function(dim=2, xmin=(3, 0.5), fmin=0.0, bounds=(-4.5, 4.5))
-def beale(xy):
-    x, y = xy
-    return (1.5 - x * y) ** 2 + (2.25 - x + x * y**2) ** 2 + (2.625 - x + x * y**3) ** 2
-
-
-_TRAY = 1.34941
-
-
-@fit_function(
-    dim=2, fmin=-2.06261, bounds=(-10, 10), xmin=((_TRAY, _TRAY), (_TRAY, -_TRAY), (-_TRAY, _TRAY), (-_TRAY, -_TRAY))
-)
-def cross_in_tray(xy):
-    x, y = xy
-    return -0.0001 * (abs(sin(x) * sin(y) * exp(abs(100 - sqrt(x**2 + y**2) / pi))) + 1) ** 0.1
-
-
-@fit_function(bounds=(-600, 600), xmin=0.0, fmin=0.0)
-def griewank(x):
-    return 1 + sum(xi**2 for xi in x) ** 2 / 4000 - prod(cos(xi / sqrt(i + 1)) for i, xi in enumerate(x))
-
-
-@fit_function(bounds=(-5.12, 5.12), xmin=0.0, fmin=0.0)
-def rastrigin(x, A=10.0):
-    """
-    Multimodal with global minimum near local minima.
-    """
-    n = len(x)
-    return A * n + sum(xi**2 - A * cos(2 * pi * xi) for xi in x)
-
-
-# could also use bounds=(-2.048, 2.048)
-@fit_function(bounds=(-5, 10), xmin=1.0, fmin=0.0)
-def rosenbrock(x):
-    """
-    Unimodal with narrow parabolic valley.
-    """
-    return sum(100 * (xn - xp**2) ** 2 + (xp - 1) ** 2 for xp, xn in zip(x[:-1], x[1:]))
-
-
-# ========================== wrapper ==================
-
-
-def plot2d(fn, args=None, range=(-10, 10)):
-    """
-    Return a mesh plotter for the given function.
-
-    *args* are the function arguments that are to be meshed (usually the
-    first two arguments to the function).  *range* is the bounding box
-    for the 2D mesh.
-
-    All arguments except the meshed arguments are held fixed.
-    """
-    fnargs, _, _, _ = inspect.getargspec(fn)
-    if len(fnargs) < 2:
-        args = fnargs[:1]
-
-        def plot1d(view=None, **kw):
-            import pylab
-
-            x = kw[args[0]]
-            r = linspace(range[0], range[1], 500)
-            kw[args[0]] = x + r
-            pylab.plot(x + r, fn(**kw))
-            pylab.xlabel(args[0])
-            pylab.ylabel("-log P(%s)" % args[0])
-
-        return plot1d
-
-    if args is None:
-        args = fnargs[:2]
-    if not all(k in fnargs for k in args):
-        raise ValueError("args %s not part of function" % str(args))
-
-    def plotter(view=None, **kw):
-        import pylab
-
-        x, y = kw[args[0]], kw[args[1]]
-        r = linspace(range[0], range[1], 200)
-        X, Y = meshgrid(x + r, y + r)
-        kw[args[0]], kw[args[1]] = X, Y
-        pylab.pcolormesh(x + r, y + r, fn(**kw))
-        pylab.plot(
-            x, y, "o", markersize=6, markerfacecolor="red", markeredgecolor="black", markeredgewidth=1, alpha=0.7
-        )
-        pylab.xlabel(args[0])
-        pylab.ylabel(args[1])
-
-    return plotter
-
-
-def columnize(L, indent="", width=79):
-    # type: (List[str], str, int) -> str
-    """
-    Format a list of strings into columns.
-
-    Returns a string with carriage returns ready for printing.
-    """
-    column_width = max(len(w) for w in L) + 1
-    num_columns = (width - len(indent)) // column_width
-    num_rows = len(L) // num_columns
-    L = L + [""] * (num_rows * num_columns - len(L))
-    columns = [L[k * num_rows : (k + 1) * num_rows] for k in range(num_columns)]
-    lines = [" ".join("%-*s" % (column_width, entry) for entry in row) for row in zip(*columns)]
-    output = indent + ("\n" + indent).join(lines)
-    return output
-
-
-USAGE = """\
-Given the name of the test function followed by dimension.  Dimension
-defaults to 2.  Available models are:
-
-""" + columnize(ModelFunction.available(), indent="    ")
+USAGE = "Give the name of the model followed by dimension (default=2)"
 
 try:
     nllf = select_function(sys.argv[1:], vector=False)
-except:
+except Exception as exc:
+    # import traceback; traceback.print_exc()
     print(USAGE, file=sys.stderr)
+    print(str(exc), file=sys.stderr)
     sys.exit(1)
 
-plot = plot2d(nllf, range=(-10, 10))
+plotter = plot2d(nllf, range=(-10, 10))
 
-M = PDF(nllf, plot=plot)
+M = PDF(nllf, plot=plotter)
 
 for p in M.parameters().values():
     # TODO: really should pull value and range out of the bounds for the

--- a/doc/examples/test_functions/model_lib.py
+++ b/doc/examples/test_functions/model_lib.py
@@ -42,8 +42,8 @@ class ModelFunction(object):
             calculator = wrapper(lambda x, y: self.f((x, y), **kw))
         else:
             args = ",".join("x%d" % j for j in range(1, k + 1))
-            context = {"self": self, "kw": kw}
-            calculator = wrapper(eval("lambda %s: self.f((%s), **kw)" % (args, args), context))
+            context = {"f": self.f, "kw": kw}
+            calculator = wrapper(eval(f"lambda {args}: f(({args}), **kw)", context))
         return calculator
 
     def fv(self, k, **kw):
@@ -236,8 +236,7 @@ def plot2d(fn, args=None, range=(-10, 10)):
     """
     import matplotlib.pyplot as plt
 
-    # fnargs, _, _, _ = inspect.getargspec(fn)
-    fnargs = list(inspect.signature(fn).parameters.keys())
+    fnargs, *_ = inspect.getfullargspec(fn)
     if len(fnargs) < 2:
         args = fnargs[:1]
 

--- a/doc/examples/test_functions/model_lib.py
+++ b/doc/examples/test_functions/model_lib.py
@@ -1,0 +1,269 @@
+"""
+A set of test functions for optimizers.
+
+Surjanovic, S. & Bingham, D. (2013).
+Virtual Library of Simulation Experiments: Test Functions and Datasets.
+Retrieved April 18, 2016, from http://www.sfu.ca/~ssurjano.
+"""
+
+import inspect
+from functools import reduce, wraps
+
+import numpy as np
+from numpy import cos, e, exp, linspace, log, log1p, meshgrid, pi, sin, sqrt, inf
+from scipy.special import gammaln
+
+
+class ModelFunction(object):
+    _registered = {}  # class mutable containing list of registered functions
+
+    def __init__(self, f, xmin, fmin, bounds, dim):
+        self.name = f.__name__
+        self.xmin = xmin
+        self.fmin = fmin
+        self.bounds = bounds
+        self.dim = dim
+        self.f = f
+
+        # register the function in the list of available functions
+        ModelFunction._registered[self.name] = self
+
+    def __call__(self, x):
+        return self.f(x)
+
+    def fk(self, k, **kw):
+        """
+        Return a function with *k* arguments f(x, y, z1, z2, ..., zk-2)
+        """
+        wrapper = wraps(self.f)
+        if k == 1:
+            calculator = wrapper(lambda x: self.f((x,), **kw))
+        elif k == 2:
+            calculator = wrapper(lambda x, y: self.f((x, y), **kw))
+        else:
+            args = ",".join("x%d" % j for j in range(1, k + 1))
+            context = {"self": self, "kw": kw}
+            calculator = wrapper(eval("lambda %s: self.f((%s), **kw)" % (args, args), context))
+        return calculator
+
+    def fv(self, k, **kw):
+        """
+        Return a function with arguments f(v) for vector v.
+        """
+        wrapper = wraps(self.f)
+        calculator = wrapper(lambda x: self.f(x, **kw))
+        return calculator
+
+    @staticmethod
+    def lookup(name):
+        return ModelFunction._registered.get(name, None)
+
+    @staticmethod
+    def available():
+        return list(sorted(ModelFunction._registered.keys()))
+
+
+def select_function(argv, vector=True):
+    if len(argv) == 0:
+        raise ValueError("no function provided")
+
+    model = ModelFunction.lookup(argv[0])
+    if model is None:
+        available = columnize(ModelFunction.available(), indent="    ")
+        raise ValueError(f"Unknown model {argv[0]}. Use one of:\n{available}")
+
+    dim = int(argv[1]) if len(argv) > 1 else 2
+
+    return model.fv(dim) if vector else model.fk(dim)
+
+
+def fit_function(xmin=None, fmin=None, bounds=(-inf, inf), dim=None):
+    return lambda f: ModelFunction(f, xmin, fmin, bounds, dim)
+
+
+def columnize(L, indent="", width=79):
+    # type: (List[str], str, int) -> str
+    """
+    Format a list of strings into columns.
+
+    Returns a string with carriage returns ready for printing.
+    """
+    column_width = max(len(w) for w in L) + 1
+    num_columns = (width - len(indent)) // column_width
+    num_rows = len(L) // num_columns
+    L = L + [""] * (num_rows * num_columns - len(L))
+    columns = [L[k * num_rows : (k + 1) * num_rows] for k in range(num_columns)]
+    lines = [" ".join("%-*s" % (column_width, entry) for entry in row) for row in zip(*columns)]
+    output = indent + ("\n" + indent).join(lines)
+    return output
+
+
+# ================ Model functions ====================
+
+
+def prod(L):
+    return reduce(lambda x, y: x * y, L, 1)
+
+
+@fit_function(fmin=0.0, xmin=0.0)
+def gauss(x):
+    """
+    Multivariate gaussian distribution
+    """
+    # mu, sigma = 100.0, 0.001
+    mu, sigma = 3.0, 2.0
+    # note: sqrt(det(Sigma)) = p log(sigma) since Sigma = sigma^2 eye(p)
+    # log_norm = 0.5*len(x)*log(2*pi*sigma**2)
+    log_norm = 0
+    return 0.5 * sum(((xi - mu) / sigma) ** 2 for xi in x) - log_norm
+
+
+@fit_function(fmin=0.0, xmin=0.0)
+def t(x):
+    """
+    Multivariate t distribution
+    """
+    mu, sigma, nu = 3.0, 1.0, 2
+    p = len(x)
+    S = sum(((xi - mu) / sigma) ** 2 for xi in x) / nu
+    # note: sqrt(det(Sigma)) = p log(sigma) since Sigma = sigma^2 eye(p)
+    log_norm = gammaln(0.5 * (nu + p)) - gammaln(0.5 * nu) - 0.5 * p * log(nu + pi) - p * log(sigma)
+    return (nu + p) / 2 * log1p(S) - log_norm
+
+
+@fit_function(fmin=0.0, xmin=3.0)
+def laplace(x):
+    """
+    Product of Laplace distributions, mu=3, b=0.1.
+    """
+    return sum(abs(xi - 3.0) / 0.1 for xi in x)
+
+
+@fit_function(fmin=0.0, xmin=3.0)
+def sin_plus_quadratic(x, c=3.0, d=2.0, m=5.0, h=2.0):
+    """
+    Sin + quadratic.  Multimodal with global minimum.
+
+    *c* is the center point where the function is minimized.
+
+    *d* is the distance between modes, one per dimension.
+
+    *h* is the sine wave amplitude, on per dimension, which controls
+    the height of the barrier between modes.
+
+    *m* is the curvature of the quadratic, one per dimension.
+    """
+    n = len(x)
+    if np.isscalar(c):
+        c = [c] * n
+    if np.isscalar(d):
+        d = [d] * n
+    if np.isscalar(h):
+        h = [h] * n
+    if np.isscalar(m):
+        m = [m] * n
+    return sum(hi * (sin((2 * pi / di) * xi - ci) + 1.0) for xi, ci, di, hi in zip(x, c, d, h)) + sum(
+        ((xi - ci) / float(mi)) ** 2 for xi, ci, mi in zip(x, c, m)
+    )
+
+
+@fit_function(fmin=0.0, xmin=0.0)
+def stepped_well(x):
+    return sum(np.floor(abs(xi)) for xi in x)
+
+
+@fit_function(xmin=0.0, fmin=0.0, bounds=(-32.768, 32.768))
+def ackley(x, a=20.0, b=0.2, c=2 * pi):
+    """
+    Multimodal with deep global minimum.
+    """
+    n = len(x)
+    return -a * exp(-b * sqrt(sum(xi**2 for xi in x) / n)) - exp(sum(cos(c * xi) for xi in x) / n) + a + e
+
+
+@fit_function(dim=2, xmin=(3, 0.5), fmin=0.0, bounds=(-4.5, 4.5))
+def beale(xy):
+    x, y = xy
+    return (1.5 - x * y) ** 2 + (2.25 - x + x * y**2) ** 2 + (2.625 - x + x * y**3) ** 2
+
+
+_TRAY = 1.34941
+
+
+@fit_function(
+    dim=2, fmin=-2.06261, bounds=(-10, 10), xmin=((_TRAY, _TRAY), (_TRAY, -_TRAY), (-_TRAY, _TRAY), (-_TRAY, -_TRAY))
+)
+def cross_in_tray(xy):
+    x, y = xy
+    return -0.0001 * (abs(sin(x) * sin(y) * exp(abs(100 - sqrt(x**2 + y**2) / pi))) + 1) ** 0.1
+
+
+@fit_function(bounds=(-600, 600), xmin=0.0, fmin=0.0)
+def griewank(x):
+    return 1 + sum(xi**2 for xi in x) ** 2 / 4000 - prod(cos(xi / sqrt(i + 1)) for i, xi in enumerate(x))
+
+
+@fit_function(bounds=(-5.12, 5.12), xmin=0.0, fmin=0.0)
+def rastrigin(x, A=10.0):
+    """
+    Multimodal with global minimum near local minima.
+    """
+    n = len(x)
+    return A * n + sum(xi**2 - A * cos(2 * pi * xi) for xi in x)
+
+
+# could also use bounds=(-2.048, 2.048)
+@fit_function(bounds=(-5, 10), xmin=1.0, fmin=0.0)
+def rosenbrock(x):
+    """
+    Unimodal with narrow parabolic valley.
+    """
+    return sum(100 * (xn - xp**2) ** 2 + (xp - 1) ** 2 for xp, xn in zip(x[:-1], x[1:]))
+
+
+# ========================== wrapper ==================
+
+
+def plot2d(fn, args=None, range=(-10, 10)):
+    """
+    Return a mesh plotter for the given function.
+
+    *args* are the function arguments that are to be meshed (usually the
+    first two arguments to the function).  *range* is the bounding box
+    for the 2D mesh.
+
+    All arguments except the meshed arguments are held fixed.
+    """
+    import matplotlib.pyplot as plt
+
+    # fnargs, _, _, _ = inspect.getargspec(fn)
+    fnargs = list(inspect.signature(fn).parameters.keys())
+    if len(fnargs) < 2:
+        args = fnargs[:1]
+
+        def plot1d(view=None, **kw):
+            x = kw[args[0]]
+            r = linspace(range[0], range[1], 500)
+            kw[args[0]] = x + r
+            plt.plot(x + r, fn(**kw))
+            plt.xlabel(args[0])
+            plt.ylabel("-log P(%s)" % args[0])
+
+        return plot1d
+
+    if args is None:
+        args = fnargs[:2]
+    if not all(k in fnargs for k in args):
+        raise ValueError("args %s not part of function" % str(args))
+
+    def plotter(view=None, **kw):
+        x, y = kw[args[0]], kw[args[1]]
+        r = linspace(range[0], range[1], 200)
+        X, Y = meshgrid(x + r, y + r)
+        kw[args[0]], kw[args[1]] = X, Y
+        plt.pcolormesh(x + r, y + r, fn(**kw))
+        plt.plot(x, y, "o", markersize=6, markerfacecolor="red", markeredgecolor="black", markeredgewidth=1, alpha=0.7)
+        plt.xlabel(args[0])
+        plt.ylabel(args[1])
+
+    return plotter


### PR DESCRIPTION
Script args now working again. Dill was getting confused when trying to deserialize, forcing a reload of the original script.

I can't explain why it is working again. It is still be pickling a function defined in the script file, and so it should need more information to deserialize. Maybe it is because I converted PoissonCurve and PDF to dataclasses.

I refactored the code for relative imports from the script file. It now uses a temporary import hook to intercept imports from dependent modules. I removed the old relative_import support since it wasn't working.

The new code works for a single fit session but not for resume from history so for now I've disabled it. I have code to capture the context, but no way to get it into the ProblemState object.

Tested using:
```sh
$ rm /tmp/ex.h5; bumps --fit=dream --store=/tmp/ex.h5 doc/examples/curvefit/poisson.py --args poisson -b; bumps --store=/tmp/ex.h5 --fit=dream --resume -s
$ rm /tmp/ex.h5; (cd doc/examples/test_functions && PYTHONPATH=. bumps --fit=dream --store=/tmp/ex.h5 model.py --args gauss 3 -b; PYTHONPATH=. bumps --fit=dream --store=/tmp/ex.h5 --resume)
```
