### PR TITLE
Fix summary panel issues

### DIFF
--- a/bumps/webview/client/src/components/SummaryView.vue
+++ b/bumps/webview/client/src/components/SummaryView.vue
@@ -72,7 +72,7 @@ function invalidLimit(limit: string) {
   return ["", "inf", "-inf"].includes(limit) || Number.isNaN(Number(limit));
 }
 
-function selectContents(ev: MouseEvent) {
+function selectContents(ev: FocusEvent) {
   const target = ev.target as HTMLElement;
   const range = document.createRange();
   range.selectNodeContents(target);

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1425,10 +1425,7 @@ def params_to_list(params, lookup=None, pathlist=None, links=None) -> List[Param
             existing["paths"].append(".".join(pathlist))
         else:
             value_str = VALUE_FORMAT.format(nice(params.value))
-            if hasattr(params, "has_prior"):
-                has_prior = params.has_prior()
-            else:
-                has_prior = False
+            has_prior = getattr(params, "prior", None) is not None
 
             if hasattr(params, "slot"):
                 writable = type(params.slot) in [Variable, Parameter]
@@ -1445,7 +1442,6 @@ def params_to_list(params, lookup=None, pathlist=None, links=None) -> List[Param
                 "fixed": params.fixed,
             }
             if has_prior:
-                assert params.prior is not None
                 lo, hi = params.prior.limits
                 new_item["value01"] = params.prior.get01(float(params.value))
                 new_item["min_str"] = VALUE_FORMAT.format(nice(lo))


### PR DESCRIPTION
Fixes:

- when a user toggles a previously fixed parameter to "fit", now shows correct limits (even if infinite)
- disables slider for parameter when any limit is infinite
- reverts value in editable box (value, min or max) to previous value if user inputs something that is not a number
- reverts value to previous if user presses `esc` while editing
- selects contents of editable box for easy replacement on focus (click on box or tab to box, start typing replacement text)