### PR TITLE
Fix running client in dev mode

### DIFF
--- a/bumps/webview/client/vite.config.js
+++ b/bumps/webview/client/vite.config.js
@@ -11,4 +11,7 @@ export default defineConfig({
     // Plotly fails to load without this shim.
     global: {},
   },
+  optimizeDeps: {
+    include: ["plotly.js/lib/core", "plotly.js/lib/heatmap", "plotly.js/lib/bar", "json-difference"],
+  },
 });


### PR DESCRIPTION
This PR adds configuration to fix running in dev mode (hot module replacement) with 'npx vite dev', fixing a problem where some import statements in the client weren't working because the targets of the imports are CommonJS modules.