### PR TITLE
don't reorder contours in form_quantiles

### DIFF
--- a/bumps/plotutil.py
+++ b/bumps/plotutil.py
@@ -177,7 +177,7 @@ def form_quantiles(y, contours):
     from numpy import reshape
     from scipy.stats.mstats import mquantiles
 
-    p = _convert_contours_to_probabilities(reversed(sorted(contours)))
+    p = _convert_contours_to_probabilities(contours)
     q = mquantiles(y, prob=p, axis=0)
     p = reshape(p, (2, -1))
     q = reshape(q, (-1, 2, len(y[0])))


### PR DESCRIPTION
In `bumps.plotutil.form_quantiles(y: numpy.typing.ArrayLike, contours: List[float])`, the contours were internally being reordered before processing.

This causes errors when trying to align the supplied contours with the outputs, e.g. for labelling.

In this PR, the reordering is removed.  If you want your contours in descending order, sort them before providing them to the function.