### PR TITLE
Handle user deleting "active" history item in session

### DIFF
--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -523,6 +523,8 @@ class State:
         return dict(problem_history=self.history.list())
 
     def remove_history_item(self, name: str):
+        if self.shared.active_history == name:
+            self.shared.active_history = None
         self.history.remove_item(name)
 
     def reload_history_item(self, name: str):


### PR DESCRIPTION
If the user deletes the currently active history item, `state.shared.active_history` will contain an invalid handle to a history.

In this PR the change is made so that if the user deletes the currently active history item, `state.shared.active_history` is set to None (the value indicating no history item is active)