### PR TITLE
Use --session rather than --store

### DIFF
--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -538,9 +538,10 @@ def interpret_fit_options(options: BumpsOptions):
     api.state.shared.fitter_settings[fitter_id]["settings"].update(fitopts)
     api.state.parallel = options.parallel
 
+    # TODO: How do we resume if the model is saved as a pickle and can't be restored?
     # on_startup.append(lambda App: publish('', 'local_file_path', Path().absolute().parts))
     # resume only works when you have an identical problem, so we don't load from file
-    # if you are resuming the fit.
+    # if we are resuming the fit.
     if options.filename is not None and not options.resume:
         filepath = Path(options.filename).absolute()
         model_pathlist = list(filepath.parent.parts)

--- a/check_fitters.py
+++ b/check_fitters.py
@@ -40,7 +40,7 @@ def run_fit(fitter, model_args, store, seed=1):
         *BUMPS_COMMAND,
         str(model_args[0]),
         f"--fit={fitter}",
-        f"--store={store}",
+        f"--session={store}",
         f"--seed={seed}",
         "--batch",
         f"--export={str(Path(store).parent / ('T1-'+fitter))}",

--- a/doc/examples/curvefit/curve.py
+++ b/doc/examples/curvefit/curve.py
@@ -66,12 +66,12 @@ problem = FitProblem(M)
 #
 # .. parsed-literal::
 #
-#    $ bumps.py curve.py --fit=newton --steps=100 --store=T1
+#    $ bumps.py curve.py --fit=newton --steps=100 --session=fit.h5
 #
 # The ``--fit=newton`` option says to use the quasi-newton optimizer for
-# not more than 100 steps.  The ``--store=T1`` option says to store the
+# not more than 100 steps.  The ``--session=fit.h5`` option says to store the
 # initial model, the fit results and any monitoring information in the
-# directory T1.
+# HDF5 file ``fit.h5``.
 #
 # As the fit progresses, we are shown an iteration number and a cost
 # value.  The cost value is approximately the normalized $\chi^2_N$.

--- a/doc/examples/entropy/check_entropy.py
+++ b/doc/examples/entropy/check_entropy.py
@@ -41,7 +41,7 @@ where dist is one of the distributions in scipy.stats.distributions and
 p1, p2, ... are the arguments for the distribution in the order that they
 appear. For example, for the normal distribution, x ~ N(3, 0.8), use:
 
-    bumps --fit=dream --entropy  --store=/tmp/T1 check_entropy.py norm 3 0.2
+    bumps --fit=dream --entropy --session=fit.h5 check_entropy.py --args norm 3 0.2
 """
 
 

--- a/doc/examples/entropy/peak.py
+++ b/doc/examples/entropy/peak.py
@@ -8,7 +8,7 @@
 #
 # .. parsed-literal::
 #
-#    bumps peak.py N --entropy --store=/tmp/T1 --fit=dream
+#    bumps peak.py N --entropy --session=fit.h5 --fit=dream
 #
 # The parameter N is the number of data points to use within the range.
 #

--- a/doc/examples/peaks/readme.rst
+++ b/doc/examples/peaks/readme.rst
@@ -10,4 +10,4 @@ a special plot method is needed to display the data.
 This uses a library of peak functions to model the peaks. In order for this
 to work peaks.py must be on your python path. For example, on linux or mac:
 
-    PYTHONPATH=. bumps -b --fit=dream model.py --store=peaks.h5
+    PYTHONPATH=. bumps -b --fit=dream model.py --session=peaks.h5

--- a/doc/getting_started/install.rst
+++ b/doc/getting_started/install.rst
@@ -75,12 +75,12 @@ To run the webview interface with your problem showing in a browser window use::
 
 To run in batch mode with no interactive interface use::
 
-    bumps -b curve.py --store=session.hdf
+    bumps -b curve.py --session=fit.h5
 
 This runs a complete fit, appending the results to the session file T1.hdf. To later
 view the fit results use::
 
-    bumps --store=session.hdf
+    bumps --session=fit.h5
 
 There are many command line options for controlling the fit. For a complete list use::
 

--- a/doc/guide/fitting.rst
+++ b/doc/guide/fitting.rst
@@ -36,20 +36,20 @@ chance to  converge.  Restarting a number of times ``--starts=10`` gives
 a reasonably thorough search of the fit space.  Once the fit converges,
 additional starts are very quick.  From the graphical user interface, using
 ``--starts=1`` and clicking the fit button to improve the fit as needed works
-pretty well. From the command line interface, the command line will be
-something like::
+pretty well. In batch mode the command line will be something like::
 
-    bumps --fit=amoeba --steps=1000 --starts=20 --parallel model.py --store=T1
+    bumps --fit=amoeba --steps=1000 --starts=10 --parallel model.py --session=fit.h5 --export=T1
 
-Here, the results are kept in a directory ``--store=T1`` relative to the current
-directory, with files containing the current model in *model.py*, the fit
-result in *model.par* and a plots in *model-\*.png*.  The parallel option
+Here, the results will be stored in the HDF5 file ``fit.h5``. The ``T1``
+directory will contain the current model in *model.py*, the best fit
+result in *model.par* and plots in *model-\*.png*.  The parallel option
 indicates that multiple cores should be used on the cpu when running the fit.
 
 The fit may be able to be improved by using the current best fit value as
-the starting point for a new fit::
+the starting point for a new fit. The results will be appended to the session
+file. Note that the model.py file isn't required on reload::
 
-    bumps --fit=amoeba --steps=1000 --starts=20 --parallel model.py --store=T1 --pars=T1/model.par
+    bumps --fit=amoeba --steps=1000 --starts=20 --parallel --session=fit.h5
 
 If the fit is well behaved, and a numerical derivative exists, then
 switching to :ref:`fit-newton` is useful, in that it will very rapidly
@@ -57,7 +57,7 @@ converge to a nearby local minimum.
 
 ::
 
-    bumps --fit=newton model.py --pars=T1/model.par --store=T1
+    bumps --fit=newton model.py --pars=T1/model.par --session=fit.h5
 
 :ref:`fit-de` is an alternative to :ref:`fit-amoeba`, perhaps a little
 more likely to find the global minimum but somewhat slower.  This is a
@@ -68,14 +68,10 @@ of parameters in the model, so for example an 8 parameter model with
 DE's default population ``--pop=10`` would create 80 points each generation.
 This algorithms can be called from the command line as follows::
 
-    bumps --fit=de --steps=3000 --parallel model.py --store=T1
+    bumps --fit=de --steps=3000 --parallel model.py --session=fit.h5
 
 Some fitters save the complete state of the fitter on termination so that
-the fit can be resumed.  Use ``--resume=path/to/previous/store`` to resume.
-The resumed fit also needs a ``--store=path/to/store``, which could be the
-same as the resume path if you want to update it, or it could be a completely
-new path.
-
+the fit can be resumed.  Use ``--resume`` to resume from DREAM or DE.
 
 See :ref:`optimizer-guide` for a description of the available optimizers, and
 :ref:`option-guide` for a description of all the bumps options.
@@ -166,7 +162,7 @@ points can be used to estimate uncertainty on parameters.
 
 A common command line for running DREAM is::
 
-   bumps --fit=dream --burn=1000 --samples=1e5 --init=cov --parallel --pars=T1/model.par model.py --store=T2
+   bumps --fit=dream --burn=1000 --samples=1e5 --init=cov --parallel model.py --session=fit.h5
 
 
 Bayesian uncertainty analysis is described in the GUM Supplement 1,[8]
@@ -275,10 +271,7 @@ Using the posterior distribution
 ================================
 
 You can load the DREAM output population an perform uncertainty analysis
-operations after the fact.  To run an interactive bumps session
-use the following::
-
-    bumps -i
+operations after the fact.
 
 First you need to import some functions::
 
@@ -290,10 +283,9 @@ First you need to import some functions::
     from bumps.dream.stats import var_stats, format_vars
     from bumps.dream.varplot import plot_vars
 
-
 Then you need to reload the MCMC chains::
 
-    store = "/tmp/t1"   # path to the --store=/tmp/t1 directory
+    store = "/tmp/t1"   # path to the --export=/tmp/t1 directory
     modelname = "model"  # model file name without .py extension
 
     # Reload the MCMC data
@@ -446,7 +438,7 @@ The model file (call it *plot.py*) will start with the following::
     print("chisq", chisq)
 
 Assuming your model script is in model.py and you have run a fit with
-``--store=X5``, you can run this file using::
+``--export=X5``, you can run this file using::
 
     $ bumps plot.py model.py X5
 
@@ -560,7 +552,7 @@ on the fitting problem.
 Parallel tempering is run like dream, but with optional temperature
 controls::
 
-   bumps --fit=dream --burn=1000 --samples=1e5 --init=cov --parallel --pars=T1/model.par model.py --store=T2
+   bumps --fit=dream --burn=1000 --samples=1e5 --init=cov --parallel --pars=T1/model.par model.py --session=fit.h5
 
 Parallel tempering does not yet generate the uncertainty plots provided
 by DREAM.  The state is retained along the temperature for each point,
@@ -588,8 +580,8 @@ by creating a batch file (e.g., run.bat) with one line per model.  Append
 the parameter --batch to the end of the command lines so the program
 doesn't stop to show interactive graphs::
 
-    bumps model.py ... --parallel --batch
+    bumps model.py ... --parallel --batch --session=fit.h5
 
 You can view the fitted results in the GUI the next morning using::
 
-    bumps --edit model.py --pars=T1/model.par
+    bumps fit.h5

--- a/doc/guide/options.rst
+++ b/doc/guide/options.rst
@@ -51,8 +51,7 @@ Set initial parameter values from a previous fit.  The par file is a list
 of lines with parameter name followed by parameter value on each line.
 The parameters must appear with the same name and in the same order as
 the fitted parameters in the model. Additional parameters are ignored. Missing
-parameters are filled using LHS. :ref:`option-preview` will show the
-model parameters.
+parameters are filled using LHS.
 
 .. _option-shake:
 
@@ -388,7 +387,7 @@ Execution Controls
 .. _option-export:
 
 ``--export``
------------
+------------
 
 Directory in which to store the results of the fit.  Fits produce multiple
 files and plots.  Rather than cluttering up the current directory, all the
@@ -396,6 +395,7 @@ outputs are written to the store directory along with a copy of the model
 file.
 
 .. _option-session:
+
 ``--session``
 -------------
 
@@ -531,7 +531,7 @@ Special Options
 .. _option-edit:
 
 ``--webview``
-----------
+-------------
 
 If the command contains *webview* then start the Bumps user interface so that
 you can interact with the model, adjusting fitted parameters with a slider
@@ -544,3 +544,21 @@ and seeing how they impact the result.
 
 Use ``-h`` or ``--help`` to show a brief description of each
 command line option.
+
+.. _option-resynth:
+
+``--resynth``
+-------------
+
+Run a resynth uncertainty analysis on the model.  After finding a good
+minimum, you can rerun bumps with:
+
+     bumps --store=T1 --pars=T1/model.par --fit=amoeba --resynth=20 model.py
+
+This will generate 20 data simulated datasets using the initial data
+values as the mean and the data uncertainty as the standard deviation.
+Each of these datasets will be fit with the specified optimizer, and the
+resulting parameters saved in *T1/model.rsy*.  On completion, the parameter
+values can be loaded into python and averaged or histogrammed.
+
+Note: not currently available.

--- a/doc/guide/options.rst
+++ b/doc/guide/options.rst
@@ -385,9 +385,9 @@ fitter keeps the best value from the previous fit(s).
 Execution Controls
 ==================
 
-.. _option-store:
+.. _option-export:
 
-``--store``
+``--export``
 -----------
 
 Directory in which to store the results of the fit.  Fits produce multiple
@@ -395,29 +395,19 @@ files and plots.  Rather than cluttering up the current directory, all the
 outputs are written to the store directory along with a copy of the model
 file.
 
-.. _option-overwrite:
+.. _option-session:
+``--session``
+-------------
 
-``--overwrite``
----------------
-
-If the store directory already exists then you need to include overwrite on
-the command line to reuse it.  While inconvenient, this prevents accidental
-overwriting of fits that may have taken hours to generate.
-
-.. _option-checkpoint:
-
-``--checkpoint``
-----------------
-
-Save fit state every ``--checkpoint=n`` hours. [dream only]
+Path to the HDF5 session file used to store the problem and the fit results.
+Run bumps with that session file to view the output and the plots.
 
 .. _option-resume:
 
 ``--resume``
 ------------
 
-Continue fit from a previous store directory. Use ``--resume`` or ``--resume=-``
-to reuse the existing store directory.
+Continue the most recent fit in the current session file.
 
 .. _option-parallel:
 
@@ -451,16 +441,6 @@ cluster computing where the cluster nodes do not have access to the outside
 network and can't display an interactive window.  Batch is automatic
 when running with :ref:`option-mpi`.
 
-.. _option-stepmon:
-
-``--stepmon``
--------------
-
-Create a log file tracking each point examined during the fit.  This does
-not provide any real utility except for generating plots of the population
-over time, which can be useful for understanding the different fitting
-methods.
-
 
 Output Controls
 ===============
@@ -472,6 +452,8 @@ Output Controls
 
 Show uncertainties at the end of the fit using the square root of the
 diagonals of the covariance matrix. See :ref:`option-cov`.
+
+Note: not currently available.
 
 .. _option-cov:
 
@@ -485,6 +467,8 @@ derivative of each residual with respect to each parameter. If the
 likelihood function is not a simple sum of squared residuals, then
 the Hessian matrix is used for the covariance, formed from the numerical
 derivative of the likelihood with respect to pairs of parameters.
+
+Note: not currently available.
 
 .. _option-entropy:
 
@@ -514,15 +498,7 @@ entropy calcualation method. This can be one of:
   Note: use with caution. The results from this implementation are not
   consistent with other methods. DOI:10.1214/18-AOS1688
 
-
-.. _option-plot:
-
-``--plot``
-----------
-
-For problems that have different view options for plotting, select the default
-option to display.  For example, when fitting a power law to a dataset, you
-may want to choose *log* or *linear* as the output plot type.
+Note: not currently available.
 
 
 .. _option-trim:
@@ -537,25 +513,8 @@ the MCMC output files so they will be available when the fit is resumed.
 Use ``--trim=true`` to set trimming.
 
 
-.. _option-noshow:
-
-``--noshow``
-------------
-
-*No show* suppresses the plot window after the fit. This is done automatically
-when ``--batch`` is selected.
-
 Bumps Controls
 ==============
-
-.. _option-preview:
-
-``--preview``
--------------
-
-If the command contains *preview* then display model but do not perform
-a fitting operation.  Use this to see the initial model before running a fit.
-It will also show the fit range.
 
 .. _option-chisq:
 
@@ -565,82 +524,23 @@ It will also show the fit range.
 If the command contains *chisq* then show $\chi^2$ and exit.  Use this to
 check that the model does not have any syntax errors.
 
-.. _option-resynth:
-
-``--resynth``
--------------
-
-Run a resynth uncertainty analysis on the model.  After finding a good
-minimum, you can rerun bumps with:
-
-     bumps --store=T1 --pars=T1/model.par --fit=amoeba --resynth=20 model.py
-
-This will generate 20 data simulated datasets using the initial data
-values as the mean and the data uncertainty as the standard deviation.
-Each of these datasets will be fit with the specified optimizer, and the
-resulting parameters saved in *T1/model.rsy*.  On completion, the parameter
-values can be loaded into python and averaged or histogrammed.
-
-.. _option-time_model:
-
-``--time_model``
-----------------
-
-Run the model :ref:`option-steps` times and find the average run time per step.
-If :ref:`option-parallel` is used, then the models will be run in parallel.
-
-
-.. _option-profile:
-
-``--profile``
--------------
-
-Run the model :ref:`option-steps` times using the python profiler.  This can
-be useful for identifying slow parts of your model definition, or
-alternatively, finding out that the model runtime is smaller than the
-Bumps overhead.  Use a larger value of steps for better statistics.
-
 
 Special Options
 ===============
 
 .. _option-edit:
 
-``--edit``
+``--webview``
 ----------
 
-If the command contains *edit* then start the Bumps user interface so that
+If the command contains *webview* then start the Bumps user interface so that
 you can interact with the model, adjusting fitted parameters with a slider
 and seeing how they impact the result.
 
 .. _option-help:
 
-``--help``, ``-h``, ``-?``
---------------------------
+``--help``, ``-h``
+------------------
 
-Use ``-?``, ``-h`` or ``--help`` to show a brief description of each
+Use ``-h`` or ``--help`` to show a brief description of each
 command line option.
-
-
-.. _option-python:
-
-``-i``, ``-m``, ``-c``, ``-p``
-------------------------------
-
-The bumps program can be used as a python interpreter with numpy, scipy,
-matplotlib and bumps packages available.  This is useful if you do not have
-python set up on your system, and you are using a bundled executable like
-Bumps or Refl1D on windows.  Even if you have python, you may want to run the
-bumps post-analysis scripts through the bumps command which already has
-the appropriate path set up to bumps on your system.
-
-The options are:
-
-* ``-i``: run an interactive interpreter.
-
-* ``-m package.module``: run a module as main. This is similar to
-  ``python -m package.module`` with the python interpreter.
-
-* ``-c expression``: run a python command and quit.
-
-* ``-p script.py``: run a python script.

--- a/extra/mc.py
+++ b/extra/mc.py
@@ -290,8 +290,8 @@ def main():
         help="Temperature steps for exponential ladder if Tmax is not provided",
     )
     parser.add_argument("-r", "--resume", type=str, default=None, help="Resume from file")
-    parser.add_argument("-s", "--store", type=str, default="mc.out", help="Save to file")
-    parser.add_argument("-x", "--thin", type=int, default=1, help="Number of iterations between collected points")
+    parser.add_argument("-x", "--export", type=str, default="mc.out", help="Save to file")
+    parser.add_argument("--thin", type=int, default=1, help="Number of iterations between collected points")
     parser.add_argument("modelfile", type=str, nargs=1, help="bumps model file")
     parser.add_argument("modelopts", type=str, nargs="*", help="options passed to the model")
     opts = parser.parse_args()
@@ -314,7 +314,7 @@ def main():
         dtemp=opts.dT,
         npop=opts.npop,
     )
-    save_state(opts.store, sampler, tail, labels=problem.labels())
+    save_state(opts.export, sampler, tail, labels=problem.labels())
     plot_results(problem, sampler, tail, tempstats=False)
     plt.show()
 


### PR DESCRIPTION
The old program stored the results in a directory using --store. In the new program this is done with --export, while --store was used to specify the path to an hdf5 session file.

This PR drops --store/--read-store/--write-store from the command line, renaming them to --session/--read-session/--write-session.

We could keep --store as an alias for --export, though that will potentially confuse users who have been using --store=fit.h5 on the new version.