### PR TITLE
Fix mpl backend context

### DIFF
--- a/bumps/util.py
+++ b/bumps/util.py
@@ -6,10 +6,10 @@ __all__ = ["kbhit", "profile", "pushdir", "push_seed", "redirect_console"]
 
 import os
 import sys
-import math
 import types
 from dataclasses import Field, dataclass, field, fields, is_dataclass
 from io import StringIO
+from contextlib import contextmanager
 
 # this can be substituted with pydantic dataclass for schema-building...
 from typing import (
@@ -410,6 +410,19 @@ class push_seed(object):
 
     def __exit__(self, *args):
         np.random.set_state(self._state)
+
+
+@contextmanager
+def push_mpl_backend(backend="agg"):
+    """Temporarily switch to a different matplotlib backend."""
+    import matplotlib
+
+    original_backend = matplotlib.get_backend()
+    try:
+        matplotlib.use(backend)
+        yield
+    finally:
+        matplotlib.use(original_backend)
 
 
 def get_libraries(obj, libraries=None):

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1087,10 +1087,10 @@ async def get_model_uncertainty_plot():
 
     start_time = time.time()
     logger.info(f"queueing new model uncertainty plot... {start_time}")
+    errs = bumps.errplot.calc_errors_from_state(fitProblem, fit_state)
+    logger.info(f"errors calculated: {time.time() - start_time}")
     with push_mpl_backend("agg"):
         fig = plt.figure()
-        errs = bumps.errplot.calc_errors_from_state(fitProblem, fit_state)
-        logger.info(f"errors calculated: {time.time() - start_time}")
         bumps.errplot.show_errors(errs, fig=fig)
         logger.info(f"time to render but not serialize... {time.time() - start_time}")
         fig.canvas.draw()

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -743,11 +743,9 @@ def main(options: Optional[BumpsOptions] = None):
     # Need to set matplotlib to a non-interactive backend because it is being used in the
     # the export thread. The next_color method calls gca() which needs to produce a blank
     # graph even when there is none (we ask for next color before making the plot).
-    import matplotlib as mpl
     from bumps.mapper import using_mpi
     from .webserver import start_from_cli
 
-    mpl.use("agg")
     if options is None:
         options = get_commandline_options()
 

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -6,16 +6,12 @@ import socket
 from pathlib import Path
 from typing import Callable, Optional, Union, List
 
-import matplotlib
-
 # from .main import setup_bumps
 from . import cli
 from . import api
 from . import persistent_settings
 from .logger import logger
 from .cli import BumpsOptions
-
-matplotlib.use("agg")
 
 mimetypes.add_type("text/css", ".css")
 mimetypes.add_type("text/html", ".html")


### PR DESCRIPTION
#317 was not merged into master. Description reproduced below.

---

Normal matplotlib plotting interactions, such as %matplotlib inline in a jupyter notebook, were not working after bumps was imported.

Rather than forcing matplotlib.use("agg") when bumps is started, set up a context manager to which switches to agg for plots that are to be exported, then switches back to the backend that was active before the plot was requested.

This does not appear to interfere with webview plotting, webview export or batch mode.

Tested in a jupyter notebook using the webview server running in a cell, and using the simple result = fit(problem, method='dream') interface with followed by result.state.show().