### PR TITLE
Match `requires-python` and test coverage

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -64,11 +64,11 @@ jobs:
       matrix:
         cfg:
           #- { os: ubuntu-latest, py: 3.8 }
-          #- { os: ubuntu-latest, py: 3.9, doc: 1 }
-          #- { os: ubuntu-latest, py: "3.10" }
-          - { os: ubuntu-latest, py: 3.11, doc: 1 }
-          - { os: ubuntu-latest, py: 3.12 }
-          - { os: ubuntu-latest, py: 3.13 }
+          - { os: ubuntu-latest, py: "3.9" }
+          - { os: ubuntu-latest, py: "3.10" }
+          - { os: ubuntu-latest, py: "3.11", doc: 1 }
+          - { os: ubuntu-latest, py: "3.12" }
+          - { os: ubuntu-latest, py: "3.13" }
           - { os: windows-latest, py: "3.11" }
           - { os: macos-latest, py: "3.11" }
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Chemistry',
     'Topic :: Scientific/Engineering :: Physics',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
adjust minimum python version and tests so that all allowed python versions are tested