### PR TITLE
Clean up options processing; allow --no-flag for booleans.

### DIFF
--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -285,7 +285,7 @@ class MultiStart(FitBase):
     """
 
     name = "Multistart Monte Carlo"
-    settings = [("starts", 100), ("jump", 0.0)]
+    settings = [("starts", 100), ("jump", 0)]
 
     def __init__(self, fitter):
         FitBase.__init__(self, fitter.problem)
@@ -293,7 +293,7 @@ class MultiStart(FitBase):
 
     def solve(self, monitors: MonitorRunner, mapper=None, **options):
         starts = max(options.pop("starts", 1), 1)
-        jump = options.pop("jump", 0.0)
+        jump = options.pop("jump", 0)
         x_best, f_best, chisq_best = None, np.inf, None
         for k in range(starts):
             x, fx = self.fitter.solve(monitors=monitors, mapper=mapper, **options)
@@ -453,7 +453,8 @@ class BFGSFit(FitBase):
 
     name = "Quasi-Newton BFGS"
     id = "newton"
-    settings = [("steps", 3000), ("ftol", 1e-6), ("xtol", 1e-12), ("starts", 1), ("jump", 0.0)]
+    # TODO: are these defaults a problem when the problem is single precision? See issue #110.
+    settings = [("steps", 3000), ("ftol", 1e-6), ("xtol", 1e-12), ("starts", 1), ("jump", 0)]
 
     def solve(self, monitors: MonitorRunner, mapper=None, **options):
         options = _fill_defaults(options, self.settings)
@@ -526,7 +527,7 @@ class RLFit(FitBase):
 
     name = "Random Lines"
     id = "rl"
-    settings = [("steps", 3000), ("pop", 0.5), ("CR", 0.9), ("starts", 20), ("jump", 0.0)]
+    settings = [("steps", 3000), ("pop", 0.5), ("CR", 0.9), ("starts", 20), ("jump", 0)]
 
     def solve(self, monitors: MonitorRunner, mapper=None, **options):
         from .random_lines import random_lines
@@ -635,7 +636,7 @@ class MPFit(FitBase):
 
     name = "Levenberg-Marquardt"
     id = "lm"
-    settings = [("steps", 200), ("ftol", 1e-10), ("xtol", 1e-10), ("starts", 1), ("jump", 0.0)]
+    settings = [("steps", 200), ("ftol", 1e-10), ("xtol", 1e-10), ("starts", 1), ("jump", 0)]
 
     def solve(self, monitors=None, mapper=None, **options):
         from .mpfit import mpfit
@@ -864,7 +865,7 @@ class DreamFit(FitBase):
         ("thin", 1),
         ("alpha", 0.0),
         ("outliers", "iqr"),
-        ("trim", False),
+        ("trim", True),
         ("steps", 0),  # deprecated: use --samples instead
     ]
 

--- a/bumps/webview/server/webserver.py
+++ b/bumps/webview/server/webserver.py
@@ -11,7 +11,7 @@ from . import cli
 from . import api
 from . import persistent_settings
 from .logger import logger
-from .cli import BumpsOptions
+from .cli import BumpsOptions, PREFERRED_PORT
 
 mimetypes.add_type("text/css", ".css")
 mimetypes.add_type("text/html", ".html")
@@ -22,7 +22,6 @@ mimetypes.add_type("image/png", ".png")
 mimetypes.add_type("image/svg+xml", ".svg")
 
 TRACE_MEMORY = False
-PREFERRED_PORT = 5148  # "SLAB"
 USE_MSGPACK = True  # use msgpack for serialization, faster than JSON
 
 # can get by name and not just by id


### PR DESCRIPTION
Improve command line help for fitting options: Showing defaults for each fitter. Show --time option along with other options. Move --pars option beside the corresponding --export option.

Allow use of `--no-flag` for boolean flags.

Change default to --no-trim for dream while keeping the flag name as "trim".

Force --no-mpi to use multiprocessing for parallelism even when running in an MPI context with multiple workers. You may want to do this, for example, when you are using MPI to run multiple independent fits in parallel.

Change no_autosave_history to autosave_history with default=True.

Tweak doc string formatting and clear up some explanations.

Hide jupyter subprocess command line options from the --help display.

Display default port number in --help.
