### PR TITLE
build_client checks for bun as well as npm

### DIFF
--- a/bumps/webview/build_client.py
+++ b/bumps/webview/build_client.py
@@ -9,21 +9,24 @@ def build_client(
     cleanup=False,
 ):
     """Build the bumps webview client."""
+    if shutil.which("bun"):
+        tool = "bun"
+    elif shutil.which("npm"):
+        tool = "npm"
+    else:
+        raise RuntimeError("npm/bun is not installed. Please install either npm or bun.")
 
-    # check if npm is installed
-    if not shutil.which("npm"):
-        raise RuntimeError("npm is not installed. Please install npm.")
     client_folder = (Path(__file__).parent / "client").resolve()
-    # check if the node_modules directory exists
     node_modules = client_folder / "node_modules"
     os.chdir(client_folder)
+
     if not no_deps or not node_modules.exists():
         print("Installing node modules...")
-        os.system("npm install")
+        os.system(f"{tool} install")
 
     # build the client
     print("Building the webview client...")
-    cmd = f"npm run build"
+    cmd = f"{tool} run build"
     if sourcemap:
         cmd += " -- --sourcemap"
     os.system(cmd)


### PR DESCRIPTION
Adds a check to use `bun` if installed, falling back to `npm`, and failing if neither are found.