### PR TITLE
Expand --version, print when running webview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# bumps specific ignores
+bumps/webview/client/node_modules/
+bumps/webview/client/dist
+
+# virtual environment
+venv/
+env/
+.venv/
+.env/
+
+# lockfiles
+uv.lock
+bun.lock
+
 # Eclipse/pycharm settings files
 .idea
 .project
@@ -36,5 +50,3 @@ __pycache__/
 # run in place sets .mplconfig
 .mplconfig
 
-bumps/webview/client/node_modules/
-bumps/webview/client/dist

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -45,6 +45,7 @@ from dataclasses import field
 import hashlib
 # from textwrap import dedent
 
+from bumps import __version__ as bumps_version
 from bumps.fitters import FIT_AVAILABLE_IDS
 from . import api
 from . import persistent_settings
@@ -137,6 +138,17 @@ class HelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelp
                 help_text += f" [default: {action.default}]"
         return help_text
 
+
+def _branding():
+    """Return a string with version and system information."""
+    output = f"{'='*55}\n"
+    output += f"{api.state.app_name}\t\t{api.state.app_version}\n"
+    if api.state.app_name != "bumps":
+        output += f"bumps\t\t{bumps_version}\n"
+    output += "Python\t\t" + ".".join(map(str, sys.version_info[:3])) + "\n"
+    output += f"Platform\t{sys.platform}\n"
+    output += f"{'='*55}\n"
+    return output
 
 def get_commandline_options(arg_defaults: Optional[Dict] = None):
     """Parse bumps command line options."""
@@ -390,12 +402,12 @@ def get_commandline_options(arg_defaults: Optional[Dict] = None):
         choices=["debug", "info", "warn", "error", "critical"],
         default="warn",
     )
-    # TODO: show version numbers for both refl1d and bumps?
+    # Show version numbers for both bumps and child program
     misc.add_argument(
         "-V",
         "--version",
         action="version",
-        version=f"%(prog)s {api.state.app_version}",
+        version=_branding(),
     )
 
     # TODO: restructure so that -b -s -r --webview override each other
@@ -909,6 +921,7 @@ def main(options: Optional[BumpsOptions] = None):
         # api.state.rank = ""
 
     if webview and is_controller:  # gui mode
+        print(_branding())
         start_from_cli(options)
     else:  # console mode
         run_batch_fit(options)


### PR DESCRIPTION
Expand version CLI option with additional info about child app, bumps, python and system platform info. 

output now looks like: 
```
> refl1d --version
=======================================================
refl1d          1.0.0rc1.post3+g19112a35.d20250930
bumps           1.0.3+d20250930
Python          3.13.7
Platform        linux
=======================================================
```

Additionally print this same info to the console when starting webview.