### PR TITLE
Support more plotly plot types in DataView panel

### DIFF
--- a/bumps/webview/client/src/components/DataView.vue
+++ b/bumps/webview/client/src/components/DataView.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import * as mpld3 from "mpld3";
+import contour from "plotly.js/lib/contour";
 import * as Plotly from "plotly.js/lib/core";
+import heatmap from "plotly.js/lib/heatmap";
+import image from "plotly.js/lib/image";
+import scatterternary from "plotly.js/lib/scatterternary";
 import { v4 as uuidv4 } from "uuid";
 import type { AsyncSocket } from "../asyncSocket";
 import { setupDrawLoop } from "../setupDrawLoop";
 
+Plotly.register([heatmap, contour, scatterternary, image]);
 // type ModelNameInfo = { name: string; model_index: number };
 // const title = "Data";
 const plot_div = ref<HTMLDivElement | null>(null);


### PR DESCRIPTION
Adds support for heatmap, countour, ternary and image plots to DataView.vue, which is used by models to show the default data view.