### PR TITLE
remove support for breaking Image traces in DataView

### DIFF
--- a/bumps/webview/client/src/components/DataView.vue
+++ b/bumps/webview/client/src/components/DataView.vue
@@ -4,13 +4,12 @@ import * as mpld3 from "mpld3";
 import contour from "plotly.js/lib/contour";
 import * as Plotly from "plotly.js/lib/core";
 import heatmap from "plotly.js/lib/heatmap";
-import image from "plotly.js/lib/image";
 import scatterternary from "plotly.js/lib/scatterternary";
 import { v4 as uuidv4 } from "uuid";
 import type { AsyncSocket } from "../asyncSocket";
 import { setupDrawLoop } from "../setupDrawLoop";
 
-Plotly.register([heatmap, contour, scatterternary, image]);
+Plotly.register([heatmap, contour, scatterternary]);
 // type ModelNameInfo = { name: string; model_index: number };
 // const title = "Data";
 const plot_div = ref<HTMLDivElement | null>(null);

--- a/bumps/webview/client/vite.config.js
+++ b/bumps/webview/client/vite.config.js
@@ -12,6 +12,13 @@ export default defineConfig({
     global: {},
   },
   optimizeDeps: {
-    include: ["plotly.js/lib/core", "plotly.js/lib/heatmap", "plotly.js/lib/bar", "json-difference"],
+    include: [
+      "plotly.js/lib/core",
+      "plotly.js/lib/heatmap",
+      "plotly.js/lib/contour",
+      "plotly.js/lib/scatterternary",
+      "plotly.js/lib/bar",
+      "json-difference"
+    ],
   },
 });


### PR DESCRIPTION
Image traces require special setup for compiling with vite (polyfill for nodejs stream library - `stream-browserify`?).  This was breaking the client builds.

Since we don't use Image traces at this time (and Heatmap seems more directly applicable to our plotting needs anyway) suggest just removing support for Image at this time.  It was only added recently to support theoretical future use.