### PR TITLE
Move freevars functionality to subclass

### DIFF
--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -51,6 +51,7 @@ import logging
 import os
 import sys
 import traceback
+from types import NoneType
 from typing import Generic, TypeVar, Union, Optional
 import warnings
 
@@ -263,7 +264,11 @@ class FitProblem(Generic[FitnessType]):
         penalty_nllf="inf",
         soft_limit: util.Optional[float] = None,  # TODO: deprecate,
         auto_tag=False,
+        freevars: NoneType = None,  # TODO: deprecate
     ):
+        if freevars is not None:
+            raise ValueError("freevars argument is removed; use FreeVarsFitProblem directly")
+
         if not isinstance(models, (list, tuple)):
             models = [models]
         if callable(constraints):


### PR DESCRIPTION
This PR moves all freevars functionality to a subclass.

This achieves:

- 99% use case (no freevars) now has simple list of models instead of generator

**NOT TESTED**
(it passes existing pytest tests, but likely will fail in real use without some more work)

**TODO**:
if this seems like a reasonable thing to do, we can add a migration so that existing serialized models with non-trivial freevars will be converted to the new class on load.