### PR TITLE
Add --cov --err and --entropy cli so examples/entropy will run

### DIFF
--- a/doc/examples/entropy/check_entropy.py
+++ b/doc/examples/entropy/check_entropy.py
@@ -21,6 +21,7 @@
 # to compute the entropy of the distribution.  We can use these to test
 # the values from bumps against known good values.
 
+import sys
 import numpy as np
 from math import log
 from scipy.stats import distributions, multivariate_normal
@@ -94,7 +95,7 @@ if len(sys.argv) > 1:
         print("unknown distribution " + dist_name)
         sys.exit()
     args = [
-        [[float(vjk) for vjk in vj.split(",")] for vj in v.split(",")]
+        [[float(vjk) for vjk in vj.split(",")] for vj in v.split(";")]
         if ";" in v
         else [float(vj) for vj in v.split(",")]
         if "," in v


### PR DESCRIPTION
Add --cov --err and --entropy command line parameters similar to those available in bumps pre-1.0. This is needed for doc/examples/entropy.py.

This code will need to be cleaned up as part of the #363 refactoring.

Pre-1.0 bumps used FitDriver to compute the covariance matrix because it was sometimes provided by the underlying optimizer. For example, L-M calculates the Jacobian at every step, and BFGS keeps a running estimate of the Hessian.

In webview the FitDriver object is only available in the fit thread, so we don't have access to it at the end of the fit command. Instead we compute it from the numerical derivative (all but dream), or generate the equivalent statistics from the posterior sample (dream). The simple fit interface (fitters.fit) still uses the old FitDriver interface, but on problem reload from session or export the FitDriver is again unavailable and it reverts to the numerical derivative. This may give slightly different results to the uncertainties depending on how we got there.

The current PR prints the summary objects at the end of the fit using _show_results() in webview/cli.py, but uses fitters.show_table() to print the results at the end of fitters.fit(). To use show_table() in cli we would need to create an OptimizeResult object. We would also need show_cov() and show_entropy(), or extend show_table to output cov and entropy. We should harmonize the OptimizeResult object returned from fitters.fit() with the fit state object held in the webview state.fit_state object so we have consistent handling of stderr and cov (#22).
