### PR TITLE
Force workers in MPMapper pool to run on single processor

### DIFF
--- a/bumps/mapper.py
+++ b/bumps/mapper.py
@@ -199,6 +199,18 @@ def _MP_setup():
     # Using MPMapper class variables to store worker globals.
     # It doesn't matter if they conflict with the controller values since
     # they are in a different process.
+
+    # Set environment variables to force single-threaded execution in numerical libraries
+    for var in [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "NUMBA_NUM_THREADS",
+        "BLIS_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    ]:
+        os.environ[var] = "1"
+
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     nice()
     # print(f"starting pool worker on {cpu_id()}")


### PR DESCRIPTION
We don't currently try to make the workers launched in the (default) `MPMapper` process pool run single-threaded.

In e.g. refl1d, the library functions that are accelerated with `numba` are compiled with `parallel=False`, but that only controls the threads that numba itself would spawn from `prange`, and does not address the parallelism built into numpy operations that are running (vectorized ufuncs)

@pkienzle saw some evidence that this was causing contention for processors when running with many cores in parallel.  After forcing single-threaded operation, it seemed to have more linear scaling.

This PR sets environment variables in the workers at initialization which should limit the worker to using only one (physical) processor.  It's possible we should also adjust the automatic cpu count to count only _physical_ cores in `MPMapper`