### PR TITLE
do not accept arbitrary kwargs when initializing Parameter

### DIFF
--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -290,11 +290,11 @@ class Parameter(ValueProtocol, SupportsPrior):
     the hard limits are restrictions on the value imposed by the model.
     For example, the thickness of a layer must be zero or more.
 
-    Any additional keyword arguments are preserved as properties of the
-    parameter. For example, *tip* and *units* for decorating an input form
-    in the GUI:
+    *discrete* is True if the parameter value must be an integer.
 
-         p = Parameter(10, name="width", units="cm", tip="Width of sample")
+    *tags* are user-supplied labels that can be used to group parameters together
+    for display or for setting values, and are used in the GUI for filtering
+    parameters.
 
     """
 


### PR DESCRIPTION
At the moment, we allow users to specify arbitrary kwargs when initializing a new Parameter object.
At the end of the init function, these key-value pairs are added to the new instance as attributes.

This can cause a variety of unexpected errors, some of which are silent.

Example:  A user tried to create a Parameter with 
`background1 = Parameter(1e-6, name="background1", range=(1e-7, 1e-4), vary=True)`

This did 1 "bad thing" and one "less bad thing"...

1. The `range` kwarg overwrote the `Parameter.range()` function, so it could no longer be used, but did not have the desired effect
2. The `vary` kwarg had no effect

If we are going to accept the existing behavior, there should be a very strong motivation to do so.