### PR TITLE
Allow tooltip text to reflow to box size

### DIFF
--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -111,7 +111,7 @@ class Setting:
         """
         self.name = name
         self.label = label
-        self.description = dedent(description)
+        self.description = flow(dedent(description))
         self.stype = stype
         self.fitters = []
         self.defaults = []
@@ -127,6 +127,39 @@ class Setting:
         else:
             fitters = [f"{fitter}={FITTER_DEFAULTS[fitter]['settings'][self.name]}" for fitter in self.fitters]
         return f"{self.label}  [{', '.join(fitters)}]\n{self.description}"
+
+
+def flow(text: str, proportional=True) -> str:
+    """Flow paragraphs in text, replacing line breaks in the paragraph with spaces.
+
+    Line breaks are preserved within indented text.
+
+    Paragraphs are separated by blank lines.
+
+    When operating on a multiline string, first call textwrap.dedent to remove the common
+    indent level.
+
+    If proportional, remove extra blanks within a line because we are displaying the text in a
+    proportional rather than fixed width font.
+    """
+    paragraphs = []
+    current = []
+    for line in text.split("\n"):
+        line = line.rstrip()
+        if proportional:
+            indent = len(line) - len(line.lstrip())
+            line = f"{line[:indent]}{' '.join(line[indent:].split())}"
+        if not line or line[0] in " \t":
+            if current:
+                paragraphs.append(" ".join(current))
+                current = []
+            if line:
+                paragraphs.append(line)
+        else:
+            current.append(line)
+    if current:
+        paragraphs.append(" ".join(current))
+    return "\n".join(paragraphs)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Tooltips were showing up with line breaks from the description string preserved. This PR replaces line breaks within a paragraph with space so that the text reflows to the box size.

Indented sections preserve line breaks.

Extra spaces are removed from between words so that the display is nicer in a proportionally spaced tooltip font.

For example,
```
Remove outlier Markov chains every n steps using the selected algorithm.
    none:   no outlier removal during fit
    iqr:    use interquartile range on likelihood
    grubbs: use t-test on likelihood
    mahal:  use distance from parameter values on the best chain
At the end of the fit the iqr algorithm is used to remove any remaining
outlier chains from the statistical results and plots.
```
is rendered as
```
Remove outlier Markov chains every n steps using the selected algorithm.
    none: no outlier removal during fit
    iqr: use interquartile range on likelihood
    grubbs: use t-test on likelihood
    mahal: use distance from parameter values on the best chain
At the end of the fit the iqr algorithm is used to remove any remaining outlier chains from the statistical results and plots.
```
