### PR TITLE
use numpy loadtxt to load dream state from MC (text) files

### DIFF
--- a/bumps/dream/state.py
+++ b/bumps/dream/state.py
@@ -399,12 +399,12 @@ def loadtxt_MSVC(fh: TextIO, report=0):
     return asarray(res)
 
 
-def path_contains_saved_state(filename):
+def path_contains_saved_state(filename: str) -> bool:
     chain_file = filename + "-chain" + EXT
     return os.path.exists(chain_file)
 
 
-def openmc(filename) -> TextIO:
+def openmc(filename: str) -> TextIO:
     # If filename ends in .mc.gz, also check for a .mc file.
     # If filename ends in .mc, also check for a .mc.gz file.
     if filename.endswith(".gz"):
@@ -426,7 +426,7 @@ def openmc(filename) -> TextIO:
     return fh
 
 
-def load_state(filename, skip=0, report=0, derived_vars=0):
+def load_state(filename: str, skip=0, report=0, derived_vars=0):
     """
     *filename* is the path to the saved MCMC state up to the final -chain.mc, etc.
     Any extension will be removed before using.


### PR DESCRIPTION
The existing function for loading contents of MC file is a python for-loop with regex lookups etc. per-line.  It is very slow.

It was included because in numpy <= 1.12, on Windows (MSVC) numpy.savetxt would output strings for `inf` and `nan` that are not compatible with the stock `loadtxt`.

This was almost 10 years ago, but there might still be MC files from that time period, from Windows, that users will want to read.

This PR introduces a wrapper function that calls `np.loadtxt` directly on the file contents, and if there is an exception it tries the old slow method.

Should cause tremendous speedups for users loading more recent large MC files (minutes -> seconds).