### PR TITLE
Fix display of Calculation parameters in webview

### DIFF
--- a/bumps/parameter.py
+++ b/bumps/parameter.py
@@ -170,6 +170,12 @@ class Calculation(ValueProtocol):  # the name Function is taken (though deprecat
     def __float__(self):
         return self.value
 
+    def __repr__(self):
+        return f'Calculation(description="{self.description}")'
+
+    def __str__(self):
+        return self.description
+
     def set_function(self, function):
         self._function = function
 

--- a/bumps/webview/client/src/components/ParameterView.vue
+++ b/bumps/webview/client/src/components/ParameterView.vue
@@ -26,6 +26,7 @@ type parameter_info = {
   min_str: string;
   max_str: string;
   active?: boolean;
+  slot_repr: string;
 };
 
 // const parameters = ref<parameter_info[]>([]);
@@ -95,6 +96,7 @@ async function setFittable(event: MouseEvent, index: number) {
         </td>
         <td>
           {{ param.name }}
+          <p v-if="!param.writable && param.slot_repr" class="slot-repr">{{ param.slot_repr }}</p>
           <div v-if="tag_filter?.show_tags">
             <span
               v-for="tag in param.tags"
@@ -124,6 +126,15 @@ async function setFittable(event: MouseEvent, index: number) {
 
 <style scoped>
 table {
-  white-space: nowrap;
+  width: 100%;
+  white-space: no-wrap;
+}
+
+.slot-repr {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-style: italic;
+  font-size: smaller;
+  word-break: break-word;
 }
 </style>

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1620,6 +1620,7 @@ class ParamInfo(TypedDict, total=False):
     id: str
     name: str
     paths: List[str]
+    slot_repr: str
     value_str: str
     fittable: bool
     fixed: bool
@@ -1627,6 +1628,7 @@ class ParamInfo(TypedDict, total=False):
     value01: float
     min_str: str
     max_str: str
+    tags: List[str]
 
 
 def params_to_list(params, lookup=None, path="", freevars=None) -> List[ParamInfo]:
@@ -1650,18 +1652,18 @@ def params_to_list(params, lookup=None, path="", freevars=None) -> List[ParamInf
         existing = lookup.get(pid, None)
         if existing is not None:
             existing["paths"].append(path)
-        elif freevars.isfree(params):
+        elif freevars is not None and freevars.isfree(params):
             # Don't include free parameters from the model in the list
             # of available parameters.
             pass
         else:
             value_str = VALUE_FORMAT.format(nice(params.value))
             writable = has_slot and isinstance(params.slot, (float, Variable, Parameter))
-            paths = [path] if not has_slot or isinstance(params.slot, (float, Variable)) else [f"{path}={params.slot}"]
             new_item: ParamInfo = {
                 "id": pid,
                 "name": str(params.name),
-                "paths": paths,
+                "paths": [path],
+                "slot_repr": str(params.slot) if has_slot else "",
                 "tags": getattr(params, "tags", []),
                 "writable": writable,
                 "value_str": value_str,


### PR DESCRIPTION
Fixes #429 

A change in the previous release (v1.0.4) was adding `str(slot)` to the path displayed in the webview GUI, which for `Calculation` objects includes the whole string representation of the class it is attached to.

This PR 

1. adds a new `slot_repr` key-value pair to the output of `api.params_to_list`.
2. adds this `slot_repr` string to the parameter display in the webview GUI when it is not empty
3. updates the `parameter.Calculation` class to have reasonable repr and str functions  