### PR TITLE
move active code out of bumps.cli so it can be deprecated

### DIFF
--- a/bumps/cli.py
+++ b/bumps/cli.py
@@ -7,14 +7,16 @@ stand alone applications with a similar interface.  For example, the
 Refl1D application uses the following::
 
     from . import fitplugin
-    import bumps.cli
-    bumps.cli.set_mplconfig(appdatadir='Refl1D')
-    bumps.cli.install_plugin(fitplugin)
-    bumps.cli.main()
+    from bumps.plugin import install_plugin
+    from bumps.plotutil import set_mplconfig
+    from bumps.cli import main as bumps_main
+    set_mplconfig(appdatadir='Refl1D')
+    install_plugin(fitplugin)
+    bumps_main()
 
 After completing a set of fits on related systems, a post-analysis script
 can use :func:`load_model` to load the problem definition and
-:func:`load_best` to load the best value  found in the fit.  This can
+:func:`load_pars` to load the best value  found in the fit.  This can
 be used for example in experiment design, where you look at the expected
 parameter uncertainty when fitting simulated data from a range of experimental
 systems.
@@ -27,7 +29,7 @@ __all__ = [
     "config_matplotlib",
     "load_model",
     "preview",
-    "load_best",
+    "load_pars",
     "save_best",
     "resynth",
 ]
@@ -43,29 +45,19 @@ from pathlib import Path
 import numpy as np
 # np.seterr(all="raise")
 
+from .plotutil import config_matplotlib, set_mplconfig
+from .plugin import install_plugin
+from .fitproblem import load_pars
+from .fitters import save_best
 from .fitters import FitDriver, StepMonitor, ConsoleMonitor, CheckpointMonitor
 from .mapper import MPMapper, MPIMapper, SerialMapper
-from . import util
 from . import initpop
 from . import __version__
-from . import plugin
-
-from .util import pushdir
-
-
-def install_plugin(p):
-    """
-    Replace symbols in :mod:`bumps.plugin` with application specific
-    methods.
-    """
-    for symbol in plugin.__all__:
-        if hasattr(p, symbol):
-            setattr(plugin, symbol, getattr(p, symbol))
 
 
 def load_model(path: Path | str, model_options: list[str] | None = None):
     """
-    *** DEPRECATED***. Use fitproblem.load_model(path, [args=...]) instead.
+    *** DEPRECATED***. Use fitproblem.load_problem(path, [args=...]) instead.
     """
     from .fitproblem import load_problem
 
@@ -86,90 +78,8 @@ def preview(problem, view=None):
     plt.show()
 
 
-def save_best(fitdriver, problem, best, view=None):
-    """
-    Save the fit data, including parameter values, uncertainties and plots.
-
-    *fitdriver* is the fitter that was used to drive the fit.
-
-    *problem* is a FitProblem instance.
-
-    *best* is the parameter set to save.
-    """
-    # Make sure the problem contains the best value
-    # TODO: avoid recalculating if problem is already at best.
-    problem.setp(best)
-    # print "remembering best"
-    pardata = "".join("%s %.15g\n" % (name, value) for name, value in zip(problem.labels(), problem.getp()))
-    open(problem.output_path + ".par", "wt").write(pardata)
-
-    fitdriver.save(problem.output_path)
-    with util.redirect_console(problem.output_path + ".err"):
-        fitdriver.show()
-        fitdriver.plot(output_path=problem.output_path, view=view)
-    # print "plotting"
-
-
-PARS_PATTERN = re.compile(r"^(?P<label>.*) (?P<value>[^ ]*)\n$")
-
-
-def load_best(problem, path):
-    """
-    Reload individual parameter values from a saved .par file.
-
-    If the label does not exist in the file, use the value from the model
-    as the default value. Ignore labels that do not exist in the model. In
-    that way we can load parameters from an old fit with minimal fuss, even
-    as we add, delete and move parameters in the model. If any parameters
-    are missing, set *problem.undefined* to the a boolean index of the
-    undefined parameters.
-
-    There is an interaction with --init=eps and the par file. If any parameters
-    are missing from the par file they will be randomized across the
-    entire parameter range using the equivalent of --init=lhs. That means
-    you can drop a # at the beginning of the line in the .par file
-    and that parameter will be shuffled on restart, with the remaining
-    parameters starting near the initial value.
-    """
-    # WARNING: Labels are not unique! Need to track multiple instances of
-    # the same label.
-    path = Path(path)
-    if not path.is_file():
-        path = path / (problem.name + ".par")
-    if not path.is_file():
-        raise ValueError("Parameter file {path} does not exist.")
-    labels = problem.labels()
-    targets = {label: [] for label in labels}
-    with open(path, "rt") as fid:
-        for line in fid:
-            m = PARS_PATTERN.match(line)
-            label, value = m.group("label"), float(m.group("value"))
-            # Accumulate values for labels only if they appear in the model.
-            if label in targets:
-                targets[label].append(value)
-
-    # Populate model with named parameters in the order they occur in the
-    # parameter file. Identify the missing parameters if any, adding them
-    # to the the problem definition as an optional "undefined" attribute with
-    # one bit for each parameter. This ugly hack is to support a previous
-    # ugly hack in which undefined parameters are initialized with LHS but
-    # defined parameters are initialized with eps, cov or random.
-    # TODO: find a better way to "free" parameters on --pars.
-    # TODO: find a way to "free" parameters on --resume.
-    values, undefined = [], []
-    for label, default_value in zip(labels, problem.getp()):
-        remaining = targets[label]
-        is_empty = not remaining
-        # popping the next value from remaining modifies targets[label]
-        values.append(default_value if is_empty else remaining.pop(0))
-        undefined.append(is_empty)
-    problem.setp(np.asarray(values))
-    if any(undefined):
-        problem.undefined = np.asarray(undefined)
-
-
 # CRUFT
-recall_best = load_best
+recall_best = load_best = load_pars
 
 
 def store_overwrite_query_gui(path):
@@ -324,7 +234,7 @@ def initial_model(opts):
     if opts.args:
         problem = load_model(opts.args[0], opts.args[1:])
         if opts.pars is not None:
-            load_best(problem, opts.pars)
+            load_pars(problem, opts.pars)
         if opts.simrandom:
             problem.randomize()
         if opts.simulate or opts.simrandom:
@@ -368,103 +278,6 @@ def resynth(fitdriver, problem, mapper, opts):
         fid.write("\n")
     problem.restore_data()
     fid.close()
-
-
-def set_mplconfig(appdatadir):
-    r"""
-    Point the matplotlib config dir to %LOCALAPPDATA%\{appdatadir}\mplconfig.
-    """
-    if hasattr(sys, "frozen"):
-        if os.name == "nt":
-            mplconfigdir = os.path.join(os.environ["LOCALAPPDATA"], appdatadir, "mplconfig")
-        elif sys.platform == "darwin":
-            mplconfigdir = os.path.join(os.path.expanduser("~/Library/Caches"), appdatadir, "mplconfig")
-        else:
-            return  # do nothing on linux
-        mplconfigdir = os.environ.setdefault("MPLCONFIGDIR", mplconfigdir)
-        if not os.path.exists(mplconfigdir):
-            os.makedirs(mplconfigdir)
-
-
-def config_matplotlib(backend=None):
-    """
-    Setup matplotlib to use a particular backend.
-
-    The backend should be 'WXAgg' for interactive use, or 'Agg' for batch.
-    This distinction allows us to run in environments such as cluster computers
-    which do not have wx installed on the compute nodes.
-
-    This function must be called before any imports to matplotlib.  To allow
-    this, modules should not import matplotlib at the module level, but instead
-    import it for each function/method that uses it.  Exceptions can be made
-    for modules which are completely dedicated to plotting, but these modules
-    should never be imported at the module level.
-    """
-    import matplotlib as mpl
-
-    # When running from a frozen environment created by py2exe, we will not
-    # have a range of backends available, and must set the default to WXAgg.
-    # With a full matplotlib distribution we can use whatever the user prefers.
-    if hasattr(sys, "frozen"):
-        if "MPLCONFIGDIR" not in os.environ:
-            raise RuntimeError(r"MPLCONFIGDIR should be set to e.g., %LOCALAPPDATA%\YourApp\mplconfig")
-        if backend is None:
-            backend = "WXAgg"
-
-    ## CRUFT: check that backend is valid, trying alternates if an import fails
-    # if backend is None:
-    #    backend = os.environ.get('MPLBACKEND', mpl.rcParams['backend'])
-    # import importlib
-    # for name in (backend, 'MacOSX', 'Qt5Agg', 'Qt4Agg', 'Gtk3Agg', 'TkAgg', 'WXAgg'):
-    #    path = 'matplotlib.backends.backend_' + name.lower()
-    #    try:
-    #        importlib.import_module(path)
-    #        backend = name
-    #        break
-    #    except ImportError:
-    #        backend = None
-
-    # Specify the backend to use for plotting and import backend dependent
-    # classes.  This must be done before importing pyplot to have an
-    # effect.  If no backend is given, let pyplot use the default.
-    if backend is not None:
-        mpl.use(backend)
-
-    # Disable interactive mode so that plots are only updated on show() or
-    # draw(). The interactive function must be called before importing pyplot,
-    # otherwise it will have no effect.
-    mpl.interactive(False)
-
-    # configure the plot style
-    line_width = 1
-    pad = 2
-    font_family = "Arial" if os.name == "nt" else "sans-serif"
-    font_size = 12
-    plot_style = {
-        "xtick.direction": "in",
-        "ytick.direction": "in",
-        "lines.linewidth": line_width,
-        "axes.linewidth": line_width,
-        "xtick.labelsize": font_size,
-        "ytick.labelsize": font_size,
-        "xtick.major.size": 5,
-        "ytick.major.size": 5,
-        "xtick.minor.size": 2.5,
-        "ytick.minor.size": 2.5,
-        "xtick.major.width": line_width,
-        "ytick.major.width": line_width,
-        "xtick.minor.width": line_width,
-        "ytick.minor.width": line_width,
-        "xtick.major.pad": pad,
-        "ytick.major.pad": pad,
-        "xtick.top": True,
-        "ytick.right": True,
-        "font.size": font_size,
-        "font.family": font_family,
-        "svg.fonttype": "none",
-        "savefig.dpi": 100,
-    }
-    mpl.rcParams.update(plot_style)
 
 
 def beep():
@@ -686,7 +499,7 @@ def main():
         best, fbest = fitdriver.fit(resume=resume_path)
         # print("time=%g"%(time.clock()-t0),file=sys.__stdout__)
         # Note: keep this in sync with the checkpoint function above
-        save_best(fitdriver, problem, best, view=opts.view)
+        save_best(fitdriver, view=opts.view)
         fitdriver.show()
         if opts.err or opts.cov:
             fitdriver.show_err()

--- a/bumps/cli.py
+++ b/bumps/cli.py
@@ -363,6 +363,7 @@ def main():
     setup_logging()
 
     if opts.edit:
+        # TODO: circular imports
         from .gui.gui_app import main as gui
 
         gui()

--- a/bumps/errplot.py
+++ b/bumps/errplot.py
@@ -50,7 +50,7 @@ import numpy as np
 
 from .dream.state import load_state
 from . import plugin
-from .cli import load_model, load_best
+from .fitproblem import load_problem, load_pars
 
 
 def reload_errors(model, store, nshown=50, random=True):
@@ -69,8 +69,8 @@ def reload_errors(model, store, nshown=50, random=True):
 
     Returns *errs* for :func:`show_errors`.
     """
-    problem = load_model(model)
-    load_best(problem, os.path.join(store, problem.name + ".par"))
+    problem = load_problem(model)
+    load_pars(problem, os.path.join(store, problem.name + ".par"))
     state = load_state(os.path.join(store, problem.name))
     state.mark_outliers()
     points = error_points_from_state(state, nshown=nshown, random=random)

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -31,10 +31,10 @@ Summary of problem attributes::
     plot(figfile: str, view: str) -> None
 
     # Set/used by bumps.cli
-    model_reset() -> None # called by load_model
-    path: str  # set by load_model
-    name: str # set by load_model
-    title: str = filename # set by load_moel
+    model_reset() -> None # called by load_problem
+    path: str  # set by load_problem
+    name: str # set by load_problem
+    title: str = filename # set by load_problem
     options: List[str]  # from sys.argv[1:]
     undefined:List[int]  # when loading a save .par file, these parameters weren't defined
     store: str # set by make_store
@@ -49,7 +49,7 @@ __all__ = ["Fitness", "FitProblem", "CovarianceMixin", "load_problem"]
 from contextlib import contextmanager
 from dataclasses import dataclass
 import logging
-import os
+import re
 import sys
 import traceback
 from typing import Generic, TypeVar, Union, Optional
@@ -346,7 +346,7 @@ class FitProblem(Generic[FitnessType], CovarianceMixin):
     linear.
     """
 
-    # TODO: problem.path is set by cli.load_model(); should we add it as standard?
+    # TODO: problem.path is set by fitproblem.load_problem(); should we add it as standard?
     name: util.Optional[str]
     models: util.List[FitnessType]
     freevars: util.Optional[parameter.FreeVariables]
@@ -969,6 +969,72 @@ class FitProblem(Generic[FitnessType], CovarianceMixin):
 
     def __setstate__(self, state):
         self.__dict__ = state
+
+
+PARS_PATTERN = re.compile(r"^(?P<label>.*) (?P<value>[^ ]*)\n$")
+
+
+def dump_pars(problem, path: Path, filename: str):
+    # TODO: Include non-fitted parameters in .par file?
+    # TODO: replaces api._write_pars
+    pardata = "".join(f"{name} {value:.15g}\n" for name, value in zip(problem.labels(), problem.getp()))
+    with open(path / filename, "wt") as fd:
+        fd.write(pardata)
+
+
+def load_pars(problem, path):
+    """
+    Reload individual parameter values from a saved .par file.
+
+    If the label does not exist in the file, use the value from the model
+    as the default value. Ignore labels that do not exist in the model. In
+    that way we can load parameters from an old fit with minimal fuss, even
+    as we add, delete and move parameters in the model. If any parameters
+    are missing, set *problem.undefined* to the a boolean index of the
+    undefined parameters.
+
+    There is an interaction with --init=eps and the par file. If any parameters
+    are missing from the par file they will be randomized across the
+    entire parameter range using the equivalent of --init=lhs. That means
+    you can drop a # at the beginning of the line in the .par file
+    and that parameter will be shuffled on restart, with the remaining
+    parameters starting near the initial value.
+    """
+    # WARNING: Labels are not unique! Need to track multiple instances of
+    # the same label.
+    path = Path(path)
+    if not path.is_file():
+        path = path / (problem.name + ".par")
+    if not path.is_file():
+        raise ValueError("Parameter file {path} does not exist.")
+    labels = problem.labels()
+    targets = {label: [] for label in labels}
+    with open(path, "rt") as fid:
+        for line in fid:
+            m = PARS_PATTERN.match(line)
+            label, value = m.group("label"), float(m.group("value"))
+            # Accumulate values for labels only if they appear in the model.
+            if label in targets:
+                targets[label].append(value)
+
+    # Populate model with named parameters in the order they occur in the
+    # parameter file. Identify the missing parameters if any, adding them
+    # to the the problem definition as an optional "undefined" attribute with
+    # one bit for each parameter. This ugly hack is to support a previous
+    # ugly hack in which undefined parameters are initialized with LHS but
+    # defined parameters are initialized with eps, cov or random.
+    # TODO: find a better way to "free" parameters on --pars.
+    # TODO: find a way to "free" parameters on --resume.
+    values, undefined = [], []
+    for label, default_value in zip(labels, problem.getp()):
+        remaining = targets[label]
+        is_empty = not remaining
+        # popping the next value from remaining modifies targets[label]
+        values.append(default_value if is_empty else remaining.pop(0))
+        undefined.append(is_empty)
+    problem.setp(np.asarray(values))
+    if any(undefined):
+        problem.undefined = np.asarray(undefined)
 
 
 # TODO: consider adding nllf_scale to FitProblem.

--- a/bumps/fitservice.py
+++ b/bumps/fitservice.py
@@ -2,20 +2,21 @@
 Fit job definition for the distributed job queue.
 """
 
+# TODO: Never used in production. Remove from tree.
+
 import os
 import sys
 import json
 
 from cloudpickle import loads
 
-from . import cli
 from . import __version__
 
 # Site configuration determines what kind of mapper to use
 # This should be true in cli.py as well
 from .mapper import MPMapper as Mapper
 from . import monitor
-from .fitters import FitDriver
+from .fitters import FitDriver, save_best
 
 
 def fitservice(request):
@@ -50,7 +51,7 @@ def fitservice(request):
     problem.show()
     print("#", " ".join(sys.argv))
     best, fbest = fitdriver.fit()
-    cli.save_best(fitdriver, problem, best)
+    save_best(fitdriver)
     matplotlib.pyplot.show()
     return list(best), fbest
 

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -19,7 +19,7 @@ from . import initpop
 from . import lsqerror
 
 from .history import History
-from .util import NDArray, format_duration, format_uncertainty
+from .util import NDArray, format_duration, format_uncertainty, redirect_console
 
 # For typing
 from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Optional
@@ -1349,6 +1349,35 @@ class FitDriver(object):
             "model": model,
             "fitter": fitter,
         }
+
+
+# CRUFT: replaced by export_fit, but still used by third parties.
+def save_best(fitdriver, problem=None, best=None, view=None):
+    """
+    Save the fit data, including parameter values, uncertainties and plots.
+
+    *fitdriver* is the fitter that was used to drive the fit.
+
+    *problem* is a FitProblem instance.
+
+    *best* is the parameter set to save.
+    """
+    if problem is None:
+        problem = fitdriver.problem
+    if best is None:
+        best = fitdriver.result[0]
+    # Make sure the problem contains the best value
+    if (problem.getp() != best).any():
+        problem.setp(best)
+    # TODO: use fitproblem.dump_pars(problem, path)
+    pardata = "".join("%s %.15g\n" % (name, value) for name, value in zip(problem.labels(), problem.getp()))
+    open(problem.output_path + ".par", "wt").write(pardata)
+
+    fitdriver.save(problem.output_path)
+    with redirect_console(problem.output_path + ".err"):
+        fitdriver.show()
+        fitdriver.plot(output_path=problem.output_path, view=view)
+    # print "plotting"
 
 
 def _fill_defaults(options: Optional[Dict[str, Any]], settings: List[Tuple[str, Any]]) -> Dict[str, Any]:

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1390,9 +1390,9 @@ def _fill_defaults(options: Optional[Dict[str, Any]], settings: List[Tuple[str, 
     return result
 
 
-FITTERS: List[FitBase] = []
-FIT_AVAILABLE_IDS = []
-FIT_ACTIVE_IDS = []
+FITTERS: list[FitBase] = []
+FIT_AVAILABLE_IDS: list[str] = []
+FIT_ACTIVE_IDS: list[str] = []
 
 
 def register(fitter, active=True):

--- a/bumps/gui/app_panel.py
+++ b/bumps/gui/app_panel.py
@@ -35,7 +35,7 @@ import wx
 import wx.aui
 
 from .. import plugin
-from ..cli import load_best, load_model
+from ..fitproblem import load_pars, load_problem
 from ..dream import stats as dream_stats
 from ..util import redirect_console
 from . import signal
@@ -589,11 +589,11 @@ class AppPanel(wx.Panel):
 
     def load_model(self, path):
         self._reload_path = path
-        model = load_model(path)
+        model = load_problem(path)
         signal.model_new(model=model)
 
     def apply_parameters(self, path):
-        load_best(self.model, path)
+        load_pars(self.model, path)
         # TODO: remove this once LHS randomization is controlled from the command line. Ticket #51
         if hasattr(self.model, "undefined"):
             del self.model.undefined

--- a/bumps/gui/gui_app.py
+++ b/bumps/gui/gui_app.py
@@ -56,14 +56,17 @@ import warnings
 
 try:
     from io import StringIO
-except:
+except ImportError:
     from StringIO import StringIO
 
 import wx, wx.aui
 
 from bumps import plugin
-from bumps import cli
+
+# TODO: undo circular import
+from bumps.cli import initial_model
 from bumps import options as bumps_options
+from bumps.plotutil import config_matplotlib
 
 from .about import APP_TITLE
 from .utilities import resource_dir, resource, log_time
@@ -147,7 +150,7 @@ class MainApp(wx.App):
             log_time("Starting to build the GUI application")
 
         # Can't delay matplotlib configuration any longer
-        cli.config_matplotlib("WXAgg")
+        config_matplotlib("WXAgg")
 
         from .app_frame import AppFrame
 
@@ -269,7 +272,7 @@ class MainApp(wx.App):
                 print("%5d  %s" % (i, p))
 
         # Put up the initial model
-        model, output = initial_model(opts)
+        model, output = initial_model_with_stdout(opts)
         if not model:
             model = plugin.new_model()
         signal.log_message(message=output)
@@ -286,12 +289,12 @@ class MainApp(wx.App):
 # ==============================================================================
 
 
-def initial_model(opts):
-    # Capture stdout from problem definition
+def initial_model_with_stdout(opts):
+    """Capture stdout from problem definition"""
     saved_stdout = sys.stdout
     sys.stdout = StringIO()
     try:
-        problem = cli.initial_model(opts)
+        problem = initial_model(opts)
         error = ""
     except Exception:
         problem = None

--- a/bumps/names.py
+++ b/bumps/names.py
@@ -88,7 +88,7 @@ from .fitproblem import FitProblem, Fitness
 
 # === jupyter notebook support ===
 from .webview.server.webserver import start_bumps, display_bumps
-from .fitproblem import load_problem
+from .fitproblem import load_problem, load_pars
 from .fitters import (
     fit,
     plot_convergence,

--- a/bumps/nested.py
+++ b/bumps/nested.py
@@ -142,7 +142,7 @@ class Sampler:
 
 
 def main():
-    from bumps.cli import load_model, load_best
+    from bumps.fitproblem import load_problem, load_pars
 
     parser = argparse.ArgumentParser(
         description="run nested sampling on bumps model with ultranest",
@@ -162,9 +162,9 @@ def main():
 
     print(opts)
     print(opts.modelfile)
-    problem = load_model(opts.modelfile[0], model_options=opts.modelopts)
+    problem = load_problem(opts.modelfile[0], model_options=opts.modelopts)
     if opts.pars:
-        load_best(problem, opts.pars)
+        load_pars(problem, opts.pars)
     sampler = Sampler(problem, opts.export)
     sampler.sample()
 

--- a/bumps/options.py
+++ b/bumps/options.py
@@ -191,7 +191,7 @@ class FitConfig(object):
     to the user in a GUI dialog for example.
 
     *values = {id: {option: value, ...}}* maps ids to the settings for
-    each fitter.  Note that in the GUI, different fitters may have there
+    each fitter.  Note that in the GUI, different fitters may have their
     settings recorded and preserved even when not selected.
 
     *active_ids = [id, id, ...]* is the list of fitters to show the user in

--- a/bumps/plotutil.py
+++ b/bumps/plotutil.py
@@ -2,7 +2,117 @@
 Pylab plotting utilities.
 """
 
-__all__ = ["auto_shift", "coordinated_colors", "dhsv", "next_color", "plot_quantiles", "form_quantiles"]
+__all__ = [
+    "config_matplotlib",
+    "auto_shift",
+    "coordinated_colors",
+    "dhsv",
+    "next_color",
+    "plot_quantiles",
+    "form_quantiles",
+]
+
+
+def set_mplconfig(appdatadir):
+    r"""
+    Point the matplotlib config dir to %LOCALAPPDATA%\{appdatadir}\mplconfig.
+    """
+    import os
+    import sys
+
+    if hasattr(sys, "frozen"):
+        if os.name == "nt":
+            mplconfigdir = os.path.join(os.environ["LOCALAPPDATA"], appdatadir, "mplconfig")
+        elif sys.platform == "darwin":
+            mplconfigdir = os.path.join(os.path.expanduser("~/Library/Caches"), appdatadir, "mplconfig")
+        else:
+            return  # do nothing on linux
+        mplconfigdir = os.environ.setdefault("MPLCONFIGDIR", mplconfigdir)
+        if not os.path.exists(mplconfigdir):
+            os.makedirs(mplconfigdir)
+
+
+def config_matplotlib(backend=None):
+    """
+    Setup matplotlib to use a particular backend.
+
+    The backend should be 'WXAgg' for interactive use, or 'Agg' for batch.
+    This distinction allows us to run in environments such as cluster computers
+    which do not have wx installed on the compute nodes.
+
+    This function must be called before any imports to matplotlib.  To allow
+    this, modules should not import matplotlib at the module level, but instead
+    import it for each function/method that uses it.  Exceptions can be made
+    for modules which are completely dedicated to plotting, but these modules
+    should never be imported at the module level.
+    """
+    import os
+    import sys
+    import matplotlib as mpl
+
+    # When running from a frozen environment created by py2exe, we will not
+    # have a range of backends available, and must set the default to WXAgg.
+    # With a full matplotlib distribution we can use whatever the user prefers.
+    if hasattr(sys, "frozen"):
+        if "MPLCONFIGDIR" not in os.environ:
+            raise RuntimeError(r"MPLCONFIGDIR should be set to e.g., %LOCALAPPDATA%\YourApp\mplconfig")
+        if backend is None:
+            backend = "WXAgg"
+
+    ## CRUFT: check that backend is valid, trying alternates if an import fails
+    # if backend is None:
+    #    backend = os.environ.get('MPLBACKEND', mpl.rcParams['backend'])
+    # import importlib
+    # for name in (backend, 'MacOSX', 'Qt5Agg', 'Qt4Agg', 'Gtk3Agg', 'TkAgg', 'WXAgg'):
+    #    path = 'matplotlib.backends.backend_' + name.lower()
+    #    try:
+    #        importlib.import_module(path)
+    #        backend = name
+    #        break
+    #    except ImportError:
+    #        backend = None
+
+    # Specify the backend to use for plotting and import backend dependent
+    # classes.  This must be done before importing pyplot to have an
+    # effect.  If no backend is given, let pyplot use the default.
+    if backend is not None:
+        mpl.use(backend)
+
+    # Disable interactive mode so that plots are only updated on show() or
+    # draw(). The interactive function must be called before importing pyplot,
+    # otherwise it will have no effect.
+    mpl.interactive(False)
+
+    # configure the plot style
+    line_width = 1
+    pad = 2
+    font_family = "Arial" if os.name == "nt" else "sans-serif"
+    font_size = 12
+    plot_style = {
+        "xtick.direction": "in",
+        "ytick.direction": "in",
+        "lines.linewidth": line_width,
+        "axes.linewidth": line_width,
+        "xtick.labelsize": font_size,
+        "ytick.labelsize": font_size,
+        "xtick.major.size": 5,
+        "ytick.major.size": 5,
+        "xtick.minor.size": 2.5,
+        "ytick.minor.size": 2.5,
+        "xtick.major.width": line_width,
+        "ytick.major.width": line_width,
+        "xtick.minor.width": line_width,
+        "ytick.minor.width": line_width,
+        "xtick.major.pad": pad,
+        "ytick.major.pad": pad,
+        "xtick.top": True,
+        "ytick.right": True,
+        "font.size": font_size,
+        "font.family": font_family,
+        "svg.fonttype": "none",
+        "savefig.dpi": 100,
+    }
+    mpl.rcParams.update(plot_style)
 
 
 def auto_shift(offset):

--- a/bumps/plugin.py
+++ b/bumps/plugin.py
@@ -18,10 +18,11 @@ Create a main program which looks like::
         import multiprocessing
         multiprocessing.freeze_support()
 
-        import bumps.cli
+        from bumps.plugin import install_plugin
+        from bumps.cli import main as bumps_main
         import mypackage.plugin
-        bumps.cli.install_plugin(mypackage.plugin)
-        bumps.cli.main()
+        install_plugin(mypackage.plugin)
+        bumps_main()
 
 You should be able to use this as a driver program for your application.
 
@@ -48,6 +49,17 @@ __all__ = [
 #
 # It also wants to modify the opts so that more plotters are available,
 # such as Fresnel.
+
+
+def install_plugin(p):
+    """
+    Replace symbols in :mod:`bumps.plugin` with application specific
+    methods.
+    """
+    symtab = globals()
+    for symbol in __all__:
+        if hasattr(p, symbol):
+            symtab[symbol] = getattr(p, symbol)
 
 
 def new_model():

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -14,7 +14,7 @@ are not particularly useful from a jupyter notebook.
 
     # Load a model script, possibly with additional command line arguments:
     path = Path("path/to/model.py")
-    problem = bp.load_model(path, args=[arg1, ...])
+    problem = bp.load_problem(path, args=[arg1, ...])
 
     # Use a problem defined in a separate jupyter cell
     await bp.set_problem(problem, new_model=False)
@@ -57,7 +57,6 @@ from bumps.fitproblem import load_problem
 from bumps.fitters import FitDriver, OptimizeResult
 from bumps.mapper import MPMapper
 from bumps.parameter import Parameter, Constant, Variable, unique
-import bumps.cli
 import bumps.fitproblem
 import bumps.dream.stats
 from bumps.dream.state import MCMCDraw
@@ -592,7 +591,7 @@ async def apply_parameters(pathlist: List[str], filename: str):
     fullpath = path / filename
     try:
         # print(f"loading parameters from {fullpath}")
-        bumps.cli.load_best(state.problem.fitProblem, fullpath)
+        bumps.fitproblem.load_pars(state.problem.fitProblem, fullpath)
         state.shared.updated_parameters = now_string()
         await log(f"Applied parameters from {fullpath}")
         await add_notification(

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -54,7 +54,7 @@ import math
 import time
 
 from bumps.fitproblem import load_problem
-from bumps.fitters import FitDriver, OptimizeResult
+from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID
 from bumps.mapper import MPMapper
 from bumps.parameter import Parameter, Constant, Variable, unique
 import bumps.fitproblem
@@ -101,10 +101,10 @@ TRACE_MEMORY = False
 # TODO: reloading the module wipes out state
 # TODO: any other state that needs to be initialized?
 
-# Initialize state
+# Initialize state with default fitter id and default options for each fitter.
 state = State()
-state.shared.selected_fitter = fit_options.DEFAULT_FITTER_ID
-state.shared.fitter_settings = deepcopy(fit_options.FITTER_DEFAULTS)
+state.shared.selected_fitter = FIT_DEFAULT_ID
+state.shared.fitter_settings = deepcopy(fit_options.get_fitter_defaults())
 
 
 def register(fn: Callable):
@@ -1536,7 +1536,7 @@ async def get_dirlisting(pathlist: Optional[List[str]] = None):
 
 @register
 async def get_fitter_defaults():
-    return fit_options.FITTER_DEFAULTS
+    return fit_options.get_fitter_defaults()
 
 
 @register

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -54,7 +54,7 @@ import math
 import time
 
 from bumps.fitproblem import load_problem
-from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID
+from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID, FIT_ACTIVE_IDS
 from bumps.mapper import MPMapper
 from bumps.parameter import Parameter, Constant, Variable, unique
 import bumps.fitproblem
@@ -104,7 +104,7 @@ TRACE_MEMORY = False
 # Initialize state with default fitter id and default options for each fitter.
 state = State()
 state.shared.selected_fitter = FIT_DEFAULT_ID
-state.shared.fitter_settings = deepcopy(fit_options.get_fitter_defaults())
+state.shared.fitter_settings = deepcopy(fit_options.get_fitter_defaults(active_only=False))
 
 
 def register(fn: Callable):
@@ -1536,7 +1536,14 @@ async def get_dirlisting(pathlist: Optional[List[str]] = None):
 
 @register
 async def get_fitter_defaults():
-    return fit_options.get_fitter_defaults()
+    # TODO: Need a better way to include experimental fitters in the web ui.
+    # This hack allows gui reset of fit options when --fit=pt is on the command line
+    # by allowing every experimental and deprecated fitter to appear in the fit selector.
+    # That all of them appear is okay since this only affects users who already know that
+    # there are experimental fitters available. It will probably break when we refactor
+    # the command line processor, or when we start webview from a jupyter notebook.
+    active_only = state.shared.selected_fitter in FIT_ACTIVE_IDS
+    return fit_options.get_fitter_defaults(active_only=active_only)
 
 
 @register

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -50,7 +50,6 @@ from copy import deepcopy
 import os
 import uuid
 import traceback
-import math
 import time
 
 from bumps.fitproblem import load_problem
@@ -65,7 +64,6 @@ from bumps.util import push_mpl_backend
 
 from . import fit_options
 from .state_hdf5_backed import (
-    UNDEFINED,
     UNDEFINED_TYPE,
     FitResult,
     State,

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -57,6 +57,12 @@ from .state_hdf5_backed import SERIALIZERS, FitResult
 # be used in the command line help without a circular import.
 PREFERRED_PORT = 5148  # "SLAB"
 
+# # CRUFT: mock old bumps.cli interfaces that may be used elsewhere
+# from bumps.fitproblem import load_pars as load_best
+# from bumps.fitproblem import load_problem as load_model
+# from bumps.fitters import save_best
+# from bumps.plotutil import config_matplotlib, set_mplconfig
+# from bumps.plugin import install_plugin
 
 # TODO: try datargs to build a parser from the typed dataclass
 
@@ -886,8 +892,7 @@ def reload_export(
 
     sys.argv is set to *args* before loading the model.
     """
-    from bumps.fitproblem import load_problem
-    from bumps.cli import load_best
+    from bumps.fitproblem import load_problem, load_pars
     from .state_hdf5_backed import SERIALIZER_EXTENSIONS
 
     # Find the .par file in the export directory
@@ -913,7 +918,7 @@ def reload_export(
         if picklefile.exists():
             try:
                 problem = load_problem(picklefile)
-                # Note: no need to load_best because serializer contained the parameters
+                # Note: no need to load pars because serializer contains the parameters
             except Exception as exc:
                 logger.warn(f"Failed to deserialize {picklefile}; look for model file")
             break
@@ -937,7 +942,7 @@ def reload_export(
 
         # Load the model script and the fitted values.
         problem = load_problem(modelfile, model_options=args)
-        load_best(problem, parfile)
+        load_pars(problem, parfile)
 
     # Load the MCMC files
     fit_result = load_fit_result(parfile)

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -53,16 +53,16 @@ from . import fit_options
 from .logger import logger, setup_console_logging, LOGLEVEL
 from .state_hdf5_backed import SERIALIZERS, FitResult
 
-# Ick! PREFERRED_PORT is here rather than in webserver so that it can
-# be used in the command line help without a circular import.
-PREFERRED_PORT = 5148  # "SLAB"
-
 # # CRUFT: mock old bumps.cli interfaces that may be used elsewhere
 # from bumps.fitproblem import load_pars as load_best
 # from bumps.fitproblem import load_problem as load_model
 # from bumps.fitters import save_best
 # from bumps.plotutil import config_matplotlib, set_mplconfig
 # from bumps.plugin import install_plugin
+
+# Ick! PREFERRED_PORT is here rather than in webserver so that it can
+# be used in the command line help without a circular import.
+PREFERRED_PORT = 5148  # "SLAB"
 
 # TODO: try datargs to build a parser from the typed dataclass
 
@@ -251,14 +251,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     # parser.add_argument('-d', '--debug', action=argparse.BooleanOptionalAction, help='autoload modules on change')
 
     # Fitter controls
-    fit_options.form_fit_options_associations()  # sets fitter list for each option
     fitter = parser.add_argument_group("Fitting options")
-    for name, option in fit_options.FIT_OPTIONS.items():
+    for name, option in fit_options.Setting.items():
         stype = option.stype
         metavar = "" if stype is bool else name.replace("_", "-").upper()
         choices = stype if isinstance(stype, list) else None
-        if name == "fit":
-            choices = FIT_AVAILABLE_IDS
         # For the trim option allow both --trim and --no-trim. The DictAction class
         # checks for leading "--no-" in the option string when assigning to bool.
         flagname = name.replace("_", "-")
@@ -271,9 +268,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
             metavar=metavar,
             nargs=0 if stype is bool else None,
             choices=choices,
-            # Don't show parameters that don't appear in the visible optimizers.
-            # For example, don't show --nT which is only available when --fit=pt.
-            help=option.build_help() if option.fitters else argparse.SUPPRESS,
+            help=option.help(),
         )
 
     # Fit outputs

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -250,6 +250,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     # parser.add_argument('-d', '--debug', action=argparse.BooleanOptionalAction, help='autoload modules on change')
 
+    # TODO: Help is missing for pt options even when --fit=pt is on the command line
     # Fitter controls
     fitter = parser.add_argument_group("Fitting options")
     for name, option in fit_options.Setting.items():

--- a/bumps/webview/server/cli.py
+++ b/bumps/webview/server/cli.py
@@ -45,7 +45,6 @@ import hashlib
 # from textwrap import dedent
 
 from bumps import __version__ as bumps_version
-from bumps.fitters import FIT_AVAILABLE_IDS
 from bumps.fitproblem import FitProblem, load_problem
 from . import api
 from . import persistent_settings
@@ -56,7 +55,7 @@ from .state_hdf5_backed import SERIALIZERS, FitResult
 # # CRUFT: mock old bumps.cli interfaces that may be used elsewhere
 # from bumps.fitproblem import load_pars as load_best
 # from bumps.fitproblem import load_problem as load_model
-# from bumps.fitters import save_best
+# from bumps.fitters import save_best # used by scattertools
 # from bumps.plotutil import config_matplotlib, set_mplconfig
 # from bumps.plugin import install_plugin
 

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -30,44 +30,41 @@ Various setting types are available:
 
 from typing import Dict, List, Tuple, Any, Callable, Optional
 from textwrap import dedent
-from argparse import ArgumentTypeError
+from argparse import ArgumentTypeError, SUPPRESS
 from dataclasses import dataclass, asdict
 
-from bumps import fitters
-from bumps.fitters import FIT_AVAILABLE_IDS
+from bumps.fitters import FitBase, FITTERS, FIT_DEFAULT_ID, FIT_AVAILABLE_IDS, FIT_ACTIVE_IDS
+
+# TODO: unify handling of fit options in jupyter, sasview, script, webview and bumps cli.
+# Current fitter is now and shared and fit options use Setting, but SasView and the wx GUI
+# still use options.FIT_CONFIG and options.FIT_FIELDS. We can move options.py into
+# gui/old_options.py, move webview/server/fit_options.py into options.py and import the
+# symbols we need, but we can't remove the old option handler until SasView and webview
+# are updated to a unified interface.
+
+# CRUFT: SasView is still using FIT_CONFIG and FIT_FIELDS
+# from bumps.gui.old_options import FIT_CONFIG, FIT_FIELDS
 
 
-def get_fitter_defaults(fitters):
+def get_fitter_defaults() -> dict[str, dict[str, Any]]:
     """
     Determines the default values for each setting of each fitter.
 
     This comes from the Fitter.settings attribute in the fitters defined by bumps.fitter,
     with an additional ("time", 0.0) setting implicit to all fitters.
+
+    Returns {fitter_id: {setting: value, ...}, ...}
     """
-    defaults = {f.id: dict(name=f.name, settings=dict(f.settings)) for f in fitters}
+    defaults = {f.id: dict(name=f.name, settings=dict(f.settings)) for f in FITTERS}
     # Add an implicit time=0 for the max time on each fitter.
     for k, v in defaults.items():
         v["settings"]["time"] = 0.0
     return defaults
 
 
-FITTERS = (
-    fitters.SimplexFit,
-    fitters.DreamFit,
-    fitters.DEFit,
-    fitters.MPFit,
-    fitters.BFGSFit,
-)
-"""Fitters visible to the user. This may be a subset of bumps.fitters.FITTERS"""
-
-DEFAULT_FITTER_ID = fitters.SimplexFit.id
-"""Default fitter if none specified"""
-
-FITTER_DEFAULTS = get_fitter_defaults(FITTERS)
-"""Fitter name and default settings for the visible fitters. This list will be amended if a hidden fitter is specified on the command line."""
-
-FIT_OPTIONS: Dict[str, "Setting"] = {}
-"""Options available to the fitters."""
+# TODO: move the setting registry into the Setting class
+_Setting_registry: dict[str, "Setting"] = {}
+# _registry: dict[str, "Setting"] = field(default_factory=dict, repr=False)
 
 
 @dataclass(init=False)
@@ -83,18 +80,12 @@ class Setting:
         description (str): Description of the setting.
 
         stype (Callable): Type of the setting.
-
-        fitters (List[str]): List of fitters that use this setting.
-
-        defaults (List[Any]): Default values for the setting across different fitters.
     """
 
     name: str
     label: str
     description: str
     stype: Callable
-    fitters: List[str]
-    defaults: List[Any]
 
     def __init__(self, name: str, label: str, stype: type, description: str):
         """
@@ -109,23 +100,71 @@ class Setting:
 
             description (str): Description of the setting.
         """
+        # These attributes are associated with each setting (name, label, description, type)
         self.name = name
         self.label = label
         self.description = flow(dedent(description))
         self.stype = stype
-        self.fitters = []
-        self.defaults = []
-        FIT_OPTIONS[name] = self
 
-    def build_help(self) -> str:
+        # Register all settings. Make sure each is only declared once.
+        if name in _Setting_registry:
+            raise RuntimeError(f'Setting("{name}", ...) already defined')
+        _Setting_registry[name] = self
+
+    @classmethod
+    def items(cls):
+        """
+        Iterate over the registered *(name, Setting)* pairs.
+        """
+        return _Setting_registry.items()
+
+    # Note: don't use __class_item__ since that will look like a type annotation
+    @classmethod
+    def get(cls, name):
+        """
+        Retrieve the setting for *name*.
+        """
+        return _Setting_registry[name]
+
+    def get_defaults(self, active_only=True):
+        """
+        Retrieve the defaults for setting *name* for all fitters that use it.
+
+        If *active_only*, only include the active fitters, not anything experimental
+        or deprecated.
+        """
+        defaults = [
+            (fitter.id, value)
+            for fitter in FITTERS
+            for setting, value in fitter.settings
+            if setting == self.name and (fitter.id in FIT_ACTIVE_IDS or not active_only)
+        ]
+        return defaults
+
+    def help(self, active_only=True) -> str:
+        """
+        Help string for the --settings option in the argument parser, or SUPPRESS if the
+        setting is only available for experimental or deprecated optimizers.
+        """
         if self.name == "time":
-            # Fit option processed by the fit driver, so common across all fitters
+            # Produces the label for the --time option. This option is processed by
+            # the fit driver, so it is common across all fitters
+            #     Max time (hours)  [all fitters]
             fitters = ["all fitters"]
         elif self.name == "fit":
-            # Not a fit option. Handled specially
-            fitters = self.fitters
+            # Produces the list of active fitters for the --fit options:
+            #     Optimizer name  [amoeba, de, dream, newton, lm]
+            fitters = FIT_ACTIVE_IDS
         else:
-            fitters = [f"{fitter}={FITTER_DEFAULTS[fitter]['settings'][self.name]}" for fitter in self.fitters]
+            # Produces the label for the setting with per-fitter default values.
+            # For --xtol this is:
+            #     x tolerance  [amoeba=1e-06, de=1e-06, newton=1e-12, lm=1e-10]
+            # Don't show parameters that don't appear in the visible optimizers.
+            # For example, don't show --nT which is only available when --fit=pt.
+            defaults = self.get_defaults(active_only=active_only)
+            if not defaults:
+                return SUPPRESS
+            fitters = [f"{fitter}={value}" for fitter, value in defaults]
         return f"{self.label}  [{', '.join(fitters)}]\n{self.description}"
 
 
@@ -202,12 +241,12 @@ class Range:
 
 
 ## Options available for the various fitters
-Setting("fit", "optimizer name", [], f"Fitting engine to use (default: {DEFAULT_FITTER_ID})")
+Setting("fit", "Optimizer name", FIT_AVAILABLE_IDS, f"Fitting engine to use (default: {FIT_DEFAULT_ID})")
 
 # Stopping conditions
 Setting(
     "steps",
-    "number of steps",
+    "Number of steps",
     int,
     """\
     Stop when iteration = steps. In Dream, when --steps=0 the number of steps is
@@ -218,7 +257,7 @@ Setting("xtol", "x tolerance", Range(0, 1), "Stop when population diameter < xto
 Setting("ftol", "f(x) tolerance", float, "Stop when variation in log likelihood < ftol.")
 Setting(
     "alpha",
-    "convergence criteria",
+    "Convergence criteria",
     Range(0, 0.1),
     """\
     Stop when probability that population is varying is less than alpha. This
@@ -231,7 +270,7 @@ Setting("time", "Max time (hours)", float, "Maximum number of hours to run the f
 # Initializers
 Setting(
     "init",
-    "initializer",
+    "Population initializer",
     list("eps lhs cov random".split()),
     """\
     Population initialization method
@@ -242,7 +281,7 @@ Setting(
 )
 Setting(
     "pop",
-    "population",
+    "Population size",
     float,
     """\
     Population size is pop times number of fitted parameters. If pop is negative
@@ -252,7 +291,7 @@ Setting("burn", "Burn-in steps", int, "Estimated number generations before conve
 Setting("samples", "Samples", int, "Number of samples to draw = pop*pars*steps.")
 Setting(
     "thin",
-    "thinning factor",
+    "Thinning factor",
     int,
     """\
     Number of iterations between samples; use a large number here if you find
@@ -261,7 +300,7 @@ Setting(
 )
 Setting(
     "outliers",
-    "outliers test",
+    "Outliers test",
     list("none iqr grubbs mahal".split()),
     """\
     Remove outlier Markov chains every n steps using the selected algorithm.
@@ -276,16 +315,16 @@ Setting(
 # Post processing
 Setting(
     "trim",
-    "burn-in trim",
+    "Burn-in trim",
     bool,
     """\
     After fitting, trim samples from early in the Markov chains before it converged.""",
 )
 
 # Parallel tempering
-Setting("nT", "number of temperatures", int, "Number of temperatures in the parallel tempering ladder")
-Setting("Tmin", "min temperature", float, "Lowest temperature in the temperture ladder")
-Setting("Tmax", "max temperature", float, "Highest temperature in the temperature ladder")
+Setting("nT", "Number of temperatures", int, "Number of temperatures in the parallel tempering ladder")
+Setting("Tmin", "Min temperature", float, "Lowest temperature in the temperture ladder")
+Setting("Tmax", "Max temperature", float, "Highest temperature in the temperature ladder")
 
 # Differential evolution
 Setting("CR", "Crossover ratio", Range(0, 1), "Proportion of parameters updated in crossover step")
@@ -296,7 +335,7 @@ Setting("F", "Scale", float, "Step-size scaling on difference vector")
 # Amoeba
 Setting(
     "radius",
-    "simplex radius",
+    "Simplex radius",
     Range(0, 0.5),
     """\
     Radius around the starting point for the initial simplex. Values are in (0, 0.5],
@@ -314,7 +353,7 @@ Setting(
 )
 Setting(
     "jump",
-    "jump radius",
+    "Jump radius",
     Range(0, 0.5),
     """\
     When running with multiple starts, we jump to a new start position for each
@@ -324,7 +363,7 @@ Setting(
 )
 
 
-def lookup_fitter(fitter_id: str):
+def lookup_fitter(fitter_id: str) -> FitBase:
     """
     Looks up a fitter by its ID.
 
@@ -338,49 +377,10 @@ def lookup_fitter(fitter_id: str):
         ValueError: If the fitter ID is unknown.
     """
     # Checking the complete list of fitters, not the restricted list for webview
-    for fitter in fitters.FITTERS:
+    for fitter in FITTERS:
         if fitter.id == fitter_id:
             return fitter
     raise ValueError(f"Unknown fitter '{fitter_id}'")
-
-
-def form_fit_options_associations():
-    """
-    Builds the association list between settings and the optimizers which use them.
-
-    Rerun after changes to fit_options.FITTERS
-    """
-    # Clear out old associations
-    del FIT_OPTIONS["fit"].stype[:]
-    for settings in FIT_OPTIONS.values():
-        del settings.fitters[:]
-        del settings.defaults[:]
-
-    # Define the new associations
-    for fitter in FITTERS:
-        fitter_id = fitter.id
-
-        # The --fit option is pressent in every fitter. Note that stype for --fit is
-        # a list of strings representing available fitters, so build up that list as well.
-        # Similarly --fit has the same default value for each fitter.
-        settings = FIT_OPTIONS["fit"]
-        settings.fitters.append(fitter_id)  # produces doc string for --fit [amoeba, dream, ...]
-        settings.stype.append(fitter_id)  # does option checking for --fit=fitter
-        settings.defaults.append(DEFAULT_FITTER_ID)
-
-        # The --time option is present in every fitter, with default = 0.
-        settings = FIT_OPTIONS["time"]
-        settings.fitters.append(fitter_id)
-        settings.defaults.append(0.0)
-
-        # Cycle through the default options for the current fitter, and for each, add
-        # the fitter and its default value to the respective lists.
-        for key, value in fitter.settings:
-            if key not in FIT_OPTIONS:
-                raise TypeError(f"Missing type and description for fit option --{key} used by {fitter_id}")
-            setting = FIT_OPTIONS[key]
-            setting.fitters.append(fitter_id)
-            setting.defaults.append(value)
 
 
 def check_options(options: Dict[str, Any], fitter_id: Optional[str] = None) -> Tuple[Dict[str, Any], List[str]]:
@@ -401,22 +401,24 @@ def check_options(options: Dict[str, Any], fitter_id: Optional[str] = None) -> T
     errors = []
     unknown = []
 
+    default_id = FIT_DEFAULT_ID
+    # available = set(fitter.id for fitter in FITTERS)
+    available_ids = FIT_AVAILABLE_IDS
+
     # Use the default fitter if none specified.
     if not fitter_id:
-        fitter_id = options.get("fit", DEFAULT_FITTER_ID)
+        fitter_id = options.get("fit", default_id)
 
     # Check that the fitter is one of the valid fitters. In this case we are using
     # all the fitters, not just the ones visible in the user interface so that we
     # can support deprecated and experimental fitters.
-    # available = set(fitter.id for fitter in FITTERS)
-    available = FIT_AVAILABLE_IDS
     # print(available)
-    if fitter_id not in available:
-        errors.append(f"Fitter {fitter_id} not in {', '.join(available)}. Using {DEFAULT_FITTER_ID} instead.")
-        fitter_id = DEFAULT_FITTER_ID
+    if fitter_id not in available_ids:
+        errors.append(f"Fitter {fitter_id} not in {', '.join(available_ids)}. Using {default_id} instead.")
+        fitter_id = default_id
 
     # TODO: default from state.share.fitter_settings instead of Fitter.settings?
-    fitter: fitters.FitBase = lookup_fitter(fitter_id)
+    fitter: FitBase = lookup_fitter(fitter_id)
     defaults: Dict[str, Any] = dict(fitter.settings)
     # print(f"defaults for {fitter_id}: {defaults}")
 
@@ -425,7 +427,7 @@ def check_options(options: Dict[str, Any], fitter_id: Optional[str] = None) -> T
     new_options = {"fit": fitter_id, "time": 0.0, **defaults}
     for key, value in options.items():
         # We have already checked the fit=value option above.
-        if key in "fit":
+        if key == "fit":
             continue
 
         # Collect invalid options for later reporting
@@ -435,7 +437,8 @@ def check_options(options: Dict[str, Any], fitter_id: Optional[str] = None) -> T
             continue
 
         # Promote int values to floats if the option expects a float
-        stype = FIT_OPTIONS[key].stype
+        setting = Setting.get(key)
+        stype = setting.stype
         if isinstance(value, int) and (stype is float or isinstance(stype, Range)):
             value = float(value)
 
@@ -494,5 +497,5 @@ def get_fit_fields():
     Returns:
         dict: Dictionary of fit fields where each key is a setting name and each value is a JSON-compatible Setting representation.
     """
-    fit_fields = dict([(k, _json_compatible_setting(v)) for k, v in FIT_OPTIONS.items()])
+    fit_fields = dict([(k, _json_compatible_setting(v)) for k, v in Setting.items()])
     return fit_fields

--- a/bumps/webview/server/fit_options.py
+++ b/bumps/webview/server/fit_options.py
@@ -46,7 +46,10 @@ from bumps.fitters import FitBase, FITTERS, FIT_DEFAULT_ID, FIT_AVAILABLE_IDS, F
 # from bumps.gui.old_options import FIT_CONFIG, FIT_FIELDS
 
 
-def get_fitter_defaults() -> dict[str, dict[str, Any]]:
+# TODO: If --fit=pt is specified then we need the pt options in the defaults
+# The problem is that the defaults are set in api.py before the command line is processed.
+# Options are to start with all and strip the inactive or start with the active and add extras
+def get_fitter_defaults(active_only=True) -> dict[str, dict[str, Any]]:
     """
     Determines the default values for each setting of each fitter.
 
@@ -55,7 +58,8 @@ def get_fitter_defaults() -> dict[str, dict[str, Any]]:
 
     Returns {fitter_id: {setting: value, ...}, ...}
     """
-    defaults = {f.id: dict(name=f.name, settings=dict(f.settings)) for f in FITTERS}
+    fitters = [f for f in FITTERS if f.id in FIT_ACTIVE_IDS] if active_only else FITTERS
+    defaults = {f.id: dict(name=f.name, settings=dict(f.settings)) for f in fitters}
     # Add an implicit time=0 for the max time on each fitter.
     for k, v in defaults.items():
         v["settings"]["time"] = 0.0

--- a/bumps/webview/server/state_hdf5_backed.py
+++ b/bumps/webview/server/state_hdf5_backed.py
@@ -44,12 +44,12 @@ except ImportError:
     warnings.warn("h5py is not available; can't access session files")
 
 from bumps import __version__
+from bumps.fitters import FIT_DEFAULT_ID
 from bumps.serialize import serialize, deserialize
 from bumps.serialize import serialize_bytes, deserialize_bytes
 from bumps.util import get_libraries
 from .logger import logger
-
-from .fit_options import lookup_fitter, DEFAULT_FITTER_ID
+from .fit_options import lookup_fitter
 
 if TYPE_CHECKING:
     import bumps
@@ -553,7 +553,7 @@ class FitResult:
     # TODO: Save labels in fit results so we don't need to walk the problem definition?
     # TODO: Save the initial value in the problem so users can reset after a fit?
     # TODO: Add the following to FitResult:
-    method: str = DEFAULT_FITTER_ID  # => shared.selected_fitter
+    method: str = FIT_DEFAULT_ID  # => shared.selected_fitter
     """Fitting method"""
     options: Dict[str, Any] = field(default_factory=dict)  # => shared.fitter_settings
     """Options used to run the fitters"""
@@ -633,7 +633,7 @@ class FitResult:
                 fitter = lookup_fitter(self.method)
                 self.fit_state = fitter.h5load(state_group)
             else:
-                self.method = DEFAULT_FITTER_ID
+                self.method = FIT_DEFAULT_ID
                 self.fit_state = None
 
 

--- a/extra/mc.py
+++ b/extra/mc.py
@@ -9,8 +9,8 @@ import numpy as np
 from numpy import inf
 
 from bumps import initpop
-from bumps.cli import load_best, load_model
 from bumps.dream import stats, views
+from bumps.fitproblem import load_problem, load_pars
 
 
 class Draw(object):
@@ -296,9 +296,9 @@ def main():
     parser.add_argument("modelopts", type=str, nargs="*", help="options passed to the model")
     opts = parser.parse_args()
 
-    problem = load_model(opts.modelfile[0], model_options=opts.modelopts)
+    problem = load_problem(opts.modelfile[0], model_options=opts.modelopts)
     if opts.pars:
-        load_best(problem, opts.pars)
+        load_pars(problem, opts.pars)
     dim = len(problem.getp())
     steps = opts.steps if opts.samples is None else (opts.samples + dim * opts.npop - 1) // (dim * opts.npop)
     preserved, state, tail = load_state(opts, dim, steps)

--- a/run.py
+++ b/run.py
@@ -9,6 +9,7 @@ Usage:
 
 import os
 import sys
+from contextlib import contextmanager
 
 
 def addpath(path):
@@ -23,9 +24,6 @@ def addpath(path):
         PYTHONPATH = path
     os.environ["PYTHONPATH"] = PYTHONPATH
     sys.path.insert(0, path)
-
-
-from contextlib import contextmanager
 
 
 @contextmanager
@@ -64,6 +62,6 @@ if __name__ == "__main__":
 
     multiprocessing.freeze_support()
     prepare()
-    import bumps.cli
+    from bumps.cli import main
 
-    bumps.cli.main()
+    main()


### PR DESCRIPTION
Redoing #426 in stages.

First move all of the active functions out of bumps/cli.py so that it can be moved or removed.

Update all references to the new locations.

Import the functions back into cli.py so that third party packages can be updated asynchronously.

Also includes step 2: restructuring of option handling so that bumps/options.py can be moved or removed.
