### PR TITLE
Fix fitter export

### DIFF
--- a/bumps/dream/stats.py
+++ b/bumps/dream/stats.py
@@ -223,10 +223,16 @@ def numpy_json(o):
     To automatically convert numpy data to lists when writing a datastream
     use json.dumps(object, default=numpy_json).
     """
-    try:
+    if isinstance(o, np.integer):
+        return int(o)
+    elif isinstance(o, np.floating):
+        return float(o)
+    elif isinstance(o, np.bool):
+        return bool(o)
+    elif isinstance(o, np.ndarray):
         return o.tolist()
-    except AttributeError:
-        raise TypeError
+    else:
+        raise TypeError(f"unexpected type found: {type(o)}, {o}")
 
 
 VAR_PATTERN = re.compile(

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1899,7 +1899,7 @@ def fit(
     if export is not None:
         from .webview.server.api import export_fit
 
-        export_fit(export, problem, result.state, basename=name)
+        export_fit(export, problem, result, basename=name)
 
     return result
 


### PR DESCRIPTION
@mdoucet reported that export from `bumps.fitter.fit` was not working for `dream` fits.

Minimal reproduction:
```python
from bumps.fitters import fit
from bumps.fitproblem import load_problem

p = load_problem("doc/examples/curvefit/curve.py")
result = fit(p, method="dream", burn=100, steps=1000, export="try-export")
```

This PR addresses two separate issues:

1. Previously the `fit` function called `export_fit` with `result.state` in the 'fit` argument.  `export_fit` looks for an attribute `fit.state`, so we need to pass `result` directly
2. The converter from numpy to json-compatible types was only handling `ndarray`, but scalars and booleans were being sent to the function as well during export.

Should be tested that it doesn't mess up sasview (@krzywon)