### PR TITLE
fix(webview): avoid network-drive stalls in get_dirlisting

### DIFF
--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1498,30 +1498,32 @@ async def get_topic_messages(topic: Optional[TopicNameType] = None, max_num=None
         return list(itertools.islice(q, start, q_length))
 
 
-@register
-async def get_dirlisting(pathlist: Optional[List[str]] = None):
-    # GET request
-    # TODO: use psutil to get disk listing as well?
+DIRLISTING_TIMEOUT = 10.0  # seconds before an unreachable path returns an error instead of hanging
+
+
+def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
+    """Walk a directory synchronously; run via asyncio.to_thread (filesystem I/O may be slow on network drives)."""
     subfolders = []
     files = []
     path = Path(state.base_path) if (pathlist is None or len(pathlist) == 0) else Path(*pathlist)
+    missing = None
     if not path.exists():
-        await add_notification(
-            f"Path does not exist: {path}, falling back to current working directory",
-            title="Error",
-            timeout=2000,
-        )
+        missing = path
         path = Path.cwd()
 
     abs_path = path.absolute()
     for p in abs_path.iterdir():
-        if not p.exists():
+        try:
+            stat = p.stat()
+        except OSError:
+            # entry vanished between iterdir() and stat(), or is a broken symlink
             continue
-        stat = p.stat()
         mtime = stat.st_mtime
         fileinfo = {"name": p.name, "modified": mtime}
         if p.is_dir():
-            fileinfo["size"] = len(list(p.glob("*")))
+            # NOTE: not counting directory contents — a glob per subfolder costs one
+            # round-trip each on network filesystems, and the count is not displayed.
+            fileinfo["size"] = 0
             subfolders.append(fileinfo)
         else:
             # files.append(p.resolve().name)
@@ -1529,7 +1531,30 @@ async def get_dirlisting(pathlist: Optional[List[str]] = None):
             files.append(fileinfo)
     # for Windows: list drives as well
     drives = os.listdrives() if hasattr(os, "listdrives") else []
-    return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files)
+    return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files), missing
+
+
+@register
+async def get_dirlisting(pathlist: Optional[List[str]] = None):
+    # GET request
+    # TODO: use psutil to get disk listing as well?
+    try:
+        result, missing = await asyncio.wait_for(
+            asyncio.to_thread(_get_dirlisting_sync, pathlist),
+            timeout=DIRLISTING_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        path_str = str(Path(*pathlist)) if pathlist else str(state.base_path)
+        return {"error": f"Timed out reading directory: {path_str} (network drive may be unreachable)"}
+    except OSError as exc:
+        return {"error": f"Cannot read directory: {exc}"}
+    if missing is not None:
+        await add_notification(
+            f"Path does not exist: {missing}, falling back to current working directory",
+            title="Error",
+            timeout=2000,
+        )
+    return result
 
 
 @register


### PR DESCRIPTION
## Problem

The webview file browser hangs for 30+ seconds when navigating network drives.

In `get_dirlisting`, for every directory entry the server:

- counts each subdirectory's contents with `len(list(p.glob("*")))` — a full glob *per subfolder*, and
- does a redundant `p.exists()` check on entries just returned by `iterdir()`,

all **synchronously on the asyncio event loop**. On a high-latency network filesystem each glob is a round trip, so a folder with many subfolders blocks the server for tens of seconds and the whole UI freezes.

## Fix

- **Skip the per-subfolder content count** (`size = 0` for directories) — the file browser renders subdirectories as name-only links, so the count is never displayed.
- **Replace the per-entry `exists()` check** with `try/except OSError` around `stat()`. The exists check was a racy guard against entries vanishing between `iterdir()` and `stat()` (or broken symlinks); the try/except handles the same cases without an extra round trip per entry.
- **Run the directory walk in a worker thread** (`asyncio.to_thread`) so it never blocks the event loop.
- **Add a 10 s timeout** for unreachable paths, returning `{"error": ...}` — the shape the frontend's existing `DirListingError` branch in `FileBrowser.vue` already handles (notification + revert to base path), though nothing on the backend exercised it until now.

Existing behavior is otherwise preserved: the return shape (`drives`, `pathlist`, `subfolders`, `files`) is unchanged, and a nonexistent path still notifies and falls back to the current working directory.

## Context

This was first developed as an override on the refl1d side (reflectometry/refl1d#376), where the PR body offered to redirect the fix here since the slow code lives in bumps and every bumps-webview consumer benefits. This is that redirect; if this lands, the refl1d override can be dropped.

## Testing

- `py_compile` clean; `ruff check`/`ruff format` introduce no new findings on the touched code.
- Smoke-tested `_get_dirlisting_sync` directly: real directory (correct shape, subfolder size 0, drives listed on Windows), missing path (falls back to cwd and reports the missing path for the notification), and `None` pathlist (uses `state.base_path`).
- The refl1d version of this fix has been in daily use against a real Windows network-drive setup: navigation that previously hung ~30 s returns promptly, and unreachable paths time out at 10 s with an error instead of freezing the UI.
