### PR TITLE
feat(webview): improve file browser drive and parent navigation

### DIFF
--- a/bumps/webview/client/src/components/FileBrowser.vue
+++ b/bumps/webview/client/src/components/FileBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, shallowRef, watch } from "vue";
+import { computed, ref, shallowRef, watch } from "vue";
 import { formatRelative } from "date-fns";
 import { addNotification } from "../app_state";
 import type { FileBrowserSettings } from "../app_state";
@@ -37,6 +37,8 @@ const step = ref(1);
 const active_search_pattern = ref<string | null>(null);
 const active_search_regexp = ref<RegExp | null>(null);
 const settings = ref<FileBrowserSettings>();
+
+const canGoUp = computed(() => pathlist.value.length > 1);
 
 function close() {
   dialog.value?.close();
@@ -79,6 +81,12 @@ function FileInfoSearch(f: FileInfo) {
 async function subdirClick(subdir: string) {
   pathlist.value.push(subdir);
   await setPath(pathlist.value);
+}
+
+async function goUp() {
+  if (pathlist.value.length > 1) {
+    await setPath(pathlist.value.slice(0, -1));
+  }
 }
 
 interface DirListing {
@@ -196,9 +204,10 @@ defineExpose({
             <button type="button" class="btn-close" aria-label="Close" @click="close"></button>
           </div>
           <div class="p-1 border-bottom">
-            <div v-if="drives.length > 1" class="container py-1 px-3">
-              <nav aria-label="breadcrumb">
+            <div v-if="drives.length > 0" class="container py-1 px-3">
+              <nav aria-label="drives">
                 <ol class="breadcrumb mb-0">
+                  <li class="breadcrumb-item fw-bold me-1">Drives:</li>
                   <li v-for="drive in drives" :key="drive" class="breadcrumb-item">
                     <a href="#" @click.prevent="setPath([drive])">{{ drive }}</a>
                   </li>
@@ -208,6 +217,9 @@ defineExpose({
             <div class="container py-1 px-3">
               <nav aria-label="breadcrumb">
                 <ol class="breadcrumb mb-0">
+                  <li v-if="canGoUp" class="breadcrumb-item">
+                    <a href="#" title="Go up one level" @click.prevent="goUp">⬆</a>
+                  </li>
                   <li v-for="(pathitem, index) in pathlist" :key="index" class="breadcrumb-item">
                     <a href="#" @click.prevent="setPath(pathlist.slice(0, index + 1))">{{ pathitem }}</a>
                   </li>
@@ -236,12 +248,14 @@ defineExpose({
             <div class="container border-bottom">
               <h5>Subdirectories:</h5>
               <div class="row row-cols-3">
+                <div v-if="canGoUp" class="col overflow-hidden">
+                  <a href="#" title="Parent directory" @click.prevent="goUp">..</a>
+                </div>
                 <div v-for="subdir in subdirlist" :key="subdir.name" class="col overflow-hidden">
                   <a href="#" :title="subdir.name" @click.prevent="subdirClick(subdir.name)">{{ subdir.name }}</a>
                 </div>
               </div>
             </div>
-            <div>show files: {{ settings?.show_files }}</div>
             <div v-if="settings?.show_files" class="container">
               <h5>Files:</h5>
               <table class="table table-sm">

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -1498,30 +1498,32 @@ async def get_topic_messages(topic: Optional[TopicNameType] = None, max_num=None
         return list(itertools.islice(q, start, q_length))
 
 
-@register
-async def get_dirlisting(pathlist: Optional[List[str]] = None):
-    # GET request
-    # TODO: use psutil to get disk listing as well?
+DIRLISTING_TIMEOUT = 10.0  # seconds before an unreachable path returns an error instead of hanging
+
+
+def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
+    """Walk a directory synchronously; run via asyncio.to_thread (filesystem I/O may be slow on network drives)."""
     subfolders = []
     files = []
     path = Path(state.base_path) if (pathlist is None or len(pathlist) == 0) else Path(*pathlist)
+    missing = None
     if not path.exists():
-        await add_notification(
-            f"Path does not exist: {path}, falling back to current working directory",
-            title="Error",
-            timeout=2000,
-        )
+        missing = path
         path = Path.cwd()
 
     abs_path = path.absolute()
     for p in abs_path.iterdir():
-        if not p.exists():
+        try:
+            stat = p.stat()
+        except OSError:
+            # entry vanished between iterdir() and stat(), or is a broken symlink
             continue
-        stat = p.stat()
         mtime = stat.st_mtime
         fileinfo = {"name": p.name, "modified": mtime}
         if p.is_dir():
-            fileinfo["size"] = len(list(p.glob("*")))
+            # NOTE: not counting directory contents — a glob per subfolder costs one
+            # round-trip each on network filesystems, and the count is not displayed.
+            fileinfo["size"] = 0
             subfolders.append(fileinfo)
         else:
             # files.append(p.resolve().name)
@@ -1529,7 +1531,30 @@ async def get_dirlisting(pathlist: Optional[List[str]] = None):
             files.append(fileinfo)
     # for Windows: list drives as well
     drives = os.listdrives() if hasattr(os, "listdrives") else []
-    return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files)
+    return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files), missing
+
+
+@register
+async def get_dirlisting(pathlist: Optional[List[str]] = None):
+    # GET request
+    # TODO: use psutil to get disk listing as well?
+    try:
+        result, missing = await asyncio.wait_for(
+            asyncio.to_thread(_get_dirlisting_sync, pathlist),
+            timeout=DIRLISTING_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        path_str = str(Path(*pathlist)) if pathlist else str(state.base_path)
+        return {"error": f"Timed out reading directory: {path_str} (network drive may be unreachable)"}
+    except OSError as exc:
+        return {"error": f"Cannot read directory: {exc}"}
+    if missing is not None:
+        await add_notification(
+            f"Path does not exist: {missing}, falling back to current working directory",
+            title="Error",
+            timeout=2000,
+        )
+    return result
 
 
 @register

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -47,7 +47,6 @@ import asyncio
 from pathlib import Path
 import json
 from copy import deepcopy
-import os
 import sys
 import uuid
 import traceback
@@ -81,6 +80,21 @@ from .traceplot import plot_trace
 from .logger import logger
 from .convergence_plot import convergence_plot
 from .custom_plot import process_custom_plot, CustomWebviewPlot
+
+# CRUFT: os.listdrives requires python 3.12 (and only exists on windows)
+try:
+    from os import listdrives
+except ImportError:
+
+    def listdrives() -> list[str]:
+        """List Windows drive roots, e.g. ["C:\\", "D:\\"]; empty on other platforms."""
+        if sys.platform == "win32":
+            import ctypes
+
+            bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+            return [f"{chr(65 + i)}:\\" for i in range(26) if bitmask & (1 << i)]
+        return []
+
 
 # CRUFT: python 3.8 does not have asyncio.to_thread
 try:
@@ -1502,18 +1516,6 @@ async def get_topic_messages(topic: Optional[TopicNameType] = None, max_num=None
 DIRLISTING_TIMEOUT = 10.0  # seconds before an unreachable path returns an error instead of hanging
 
 
-def _get_drives() -> List[str]:
-    """List Windows drive roots, e.g. ["C:\\", "D:\\"]; empty on other platforms."""
-    if hasattr(os, "listdrives"):  # Python 3.12+
-        return os.listdrives()
-    if sys.platform == "win32":
-        import ctypes
-
-        bitmask = ctypes.windll.kernel32.GetLogicalDrives()
-        return [f"{chr(65 + i)}:\\" for i in range(26) if bitmask & (1 << i)]
-    return []
-
-
 def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
     """Walk a directory synchronously; run via asyncio.to_thread (filesystem I/O may be slow on network drives)."""
     subfolders = []
@@ -1543,7 +1545,7 @@ def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
             fileinfo["size"] = stat.st_size
             files.append(fileinfo)
     # for Windows: list drives as well
-    drives = _get_drives()
+    drives = listdrives()
     return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files), missing
 
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -48,6 +48,7 @@ from pathlib import Path
 import json
 from copy import deepcopy
 import os
+import sys
 import uuid
 import traceback
 import time
@@ -1501,6 +1502,18 @@ async def get_topic_messages(topic: Optional[TopicNameType] = None, max_num=None
 DIRLISTING_TIMEOUT = 10.0  # seconds before an unreachable path returns an error instead of hanging
 
 
+def _get_drives() -> List[str]:
+    """List Windows drive roots, e.g. ["C:\\", "D:\\"]; empty on other platforms."""
+    if hasattr(os, "listdrives"):  # Python 3.12+
+        return os.listdrives()
+    if sys.platform == "win32":
+        import ctypes
+
+        bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+        return [f"{chr(65 + i)}:\\" for i in range(26) if bitmask & (1 << i)]
+    return []
+
+
 def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
     """Walk a directory synchronously; run via asyncio.to_thread (filesystem I/O may be slow on network drives)."""
     subfolders = []
@@ -1530,7 +1543,7 @@ def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
             fileinfo["size"] = stat.st_size
             files.append(fileinfo)
     # for Windows: list drives as well
-    drives = os.listdrives() if hasattr(os, "listdrives") else []
+    drives = _get_drives()
     return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files), missing
 
 


### PR DESCRIPTION
Navigation improvements for the webview file browser, developed and daily-driven on the refl1d side (as an overridden component) and now contributed upstream where they belong.

## Changes

### 1. Drive list works on Python 3.10/3.11 (backend)

`get_dirlisting` populates `drives` via `os.listdrives()`, which only exists on **Python 3.12+**. Bumps supports **Python ≥3.10**, so Windows users on 3.10/3.11 silently get `drives = []` and the drives bar never appears. Added a `ctypes` `GetLogicalDrives()` fallback (same output, all supported versions). Non-Windows platforms still return `[]`, so the drives bar remains a Windows-only element.

### 2. Parent-directory navigation (frontend)

Currently the only way to go *up* is clicking an earlier segment of the breadcrumb. Added the two conventions users expect from file managers:

- an **⬆ button** at the front of the breadcrumb, and
- a **`..` entry** pinned at the top of the Subdirectories list.

Both go up one level and are hidden at a drive root.

### 3. Drives bar visibility + labeling (frontend)

The drives row was only shown for `drives.length > 1`; now shown for ≥1 (it doubles as a "jump to drive root" shortcut, useful even with a single drive). Added a bold **"Drives:"** label so the row of bare `C:\ D:\` links is self-explanatory, and fixed its `aria-label` — it was tagged `"breadcrumb"`, colliding with the actual breadcrumb nav below it.

### 4. Leftover debug line removed (frontend)

```html
<div>show files: {{ settings?.show_files }}</div>
```

rendered literally ("show files: true") in the dialog for every user.

## Notes

- **Stacked on #442** (`fix/network-drive-stall`) — the backend change lands inside the `_get_dirlisting_sync` helper introduced there, so this PR includes that commit. Happy to rebase onto master if #442 is declined or needs changes.
- Any of the UX pieces (2/3) can be dropped or tweaked if you have different preferences — they're independent.

## Testing

- `py_compile` clean; `_get_drives()` smoke-tested on Windows: `os.listdrives()` branch and the `ctypes` bitmask branch return the identical drive list.
- Client `biome format`, `eslint`, and `vue-tsc` checks pass on the modified component.
- The equivalent changes have been in daily use in a refl1d fork (Windows, multi-drive + network shares).
