### PR TITLE
feat: export fit results summary as <model>-fit.json

### DIFF
--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1735,6 +1735,9 @@ def _build_fit_result(problem, webview_fit):
         # Non-standard results. Note convergence is in nominal chisq
         dx=dx,
         dof=dof,
+        labels=problem.labels(),
+        numpoints=problem.model_points(),
+        chisq=problem.chisq(nllf=fx),
         # webview FitResults
         state=fit_state,
         convergence=webview_fit.convergence,
@@ -1744,45 +1747,26 @@ def _build_fit_result(problem, webview_fit):
     return results
 
 
-# OptimizeResult entries included in the exported fit results, where available.
-# The fitter state and the convergence history are excluded: the state is not
-# JSON serializable and the convergence history belongs with the plottable
-# outputs rather than the fit summary.
-_FIT_RESULT_EXPORT_FIELDS = (
-    "x",
-    "dx",
-    "fun",
-    "success",
-    "status",
-    "message",
-    "nit",
-    "nfev",
-    "dof",
-    "method",
-    "options",
-    "timestamp",
-)
+# OptimizeResult entries excluded from the exported fit results. The fitter
+# state is not JSON serializable and the convergence history belongs with the
+# plottable outputs rather than the fit summary; both are available in the
+# session file.
+_FIT_RESULT_EXCLUDE_FIELDS = ("state", "convergence")
 
 
-def fit_result_summary(problem, results: OptimizeResult) -> dict:
+def fit_result_summary(results: OptimizeResult) -> dict:
     """
-    Return a JSON-serializable summary of the fit *results* for *problem*.
+    Return a JSON-serializable summary of the fit *results*.
 
-    The summary contains the scipy-convention entries from *results* (x, dx,
-    fun, success, status, message, nit, ...) plus *labels* (the fitted
-    parameter labels, matching the order of x and dx), *points* (number of
-    data points) and *chisq* (normalized chi-squared at the best point, at
-    full precision). For a model with gaussian independent uncertainties the
-    raw sum of squares is chisq*dof.
-
-    The fitter state and the convergence history are not included.
+    The summary contains every entry from *results* except the fitter state
+    and the convergence history. This includes the scipy-convention entries
+    (x, dx, fun, success, status, message, nit, ...) plus *labels* (the
+    fitted parameter labels, matching the order of x and dx), *numpoints*
+    (number of data points) and *chisq* (normalized chi-squared at the best
+    point, at full precision). For a model with gaussian independent
+    uncertainties the raw sum of squares is chisq*dof.
     """
-    summary = {key: results[key] for key in _FIT_RESULT_EXPORT_FIELDS if key in results}
-    summary["labels"] = problem.labels()
-    summary["points"] = problem.model_points()
-    # results.fun is the nllf at the best point; chisq(nllf=None) recomputes it
-    summary["chisq"] = problem.chisq(nllf=results.get("fun"))
-    return summary
+    return {key: value for key, value in results.items() if key not in _FIT_RESULT_EXCLUDE_FIELDS}
 
 
 def save_fit_result(problem, fit, filename):
@@ -1797,50 +1781,56 @@ def save_fit_result(problem, fit, filename):
 
     results = fit if isinstance(fit, OptimizeResult) else _build_fit_result(problem, fit)
     with open(filename, "w") as fid:
-        json.dump(fit_result_summary(problem, results), fid, default=numpy_json, sort_keys=True, indent=2)
+        json.dump(fit_result_summary(results), fid, default=numpy_json, sort_keys=True, indent=2)
 
 
 def test_fit_result_summary():
     class _Problem:
         dof = 8.0
 
+        def getp(self):
+            return np.array([1.0, 2.0])
+
+        def cov(self, x):
+            return np.diag([0.01, 0.04])
+
+        def nllf(self):
+            return 20.0
+
         def labels(self):
             return ["P1", "P2"]
 
         def chisq(self, nllf=None):
-            return 2 * nllf / self.dof
+            return 2 * (self.nllf() if nllf is None else nllf) / self.dof
 
         def model_points(self):
             return 10
 
-    results = OptimizeResult(
-        x=np.array([1.0, 2.0]),
-        dx=np.array([0.1, 0.2]),
-        fun=20.0,
-        success=True,
-        status=0,
-        message="successful termination",
-        nit=100,
-        dof=8.0,
-        method="dream",
-        options={"samples": 100},
-        state=object(),  # not serializable; must be excluded
-        convergence=np.zeros((5, 6)),  # excluded
-    )
-    summary = fit_result_summary(_Problem(), results)
-    assert summary["labels"] == ["P1", "P2"]
-    assert summary["chisq"] == 5.0  # 2*20/8, full precision
-    assert summary["points"] == 10
-    assert summary["dof"] == 8.0
-    assert summary["method"] == "dream"
+    class _WebviewFit:
+        fit_state = None
+        convergence = np.zeros((5, 6))
+        method = "dream"
+        options = {"samples": 100}
+
+    results = _build_fit_result(_Problem(), _WebviewFit())
+    assert results["labels"] == ["P1", "P2"]
+    assert results["chisq"] == 5.0  # 2*20/8, full precision
+    assert results["numpoints"] == 10
+    assert results["dof"] == 8.0
+    assert results["method"] == "dream"
+
+    summary = fit_result_summary(results)
+    # everything except the fitter state and convergence history is exported
     assert "state" not in summary
     assert "convergence" not in summary
+    assert set(summary.keys()) == set(results.keys()) - set(_FIT_RESULT_EXCLUDE_FIELDS)
     # the whole summary must survive a json round trip
     from .dream.stats import numpy_json
 
     data = json.loads(json.dumps(summary, default=numpy_json))
     assert data["x"] == [1.0, 2.0]
     assert data["dx"] == [0.1, 0.2]
+    assert data["chisq"] == 5.0
 
 
 # TODO: Move simplified fit interface to its own file.
@@ -1965,6 +1955,9 @@ def fit(
         # Non-standard results. Note convergence is in nominal chisq
         dx=dx,
         dof=dof,
+        labels=problem.labels(),
+        numpoints=problem.model_points(),
+        chisq=problem.chisq(nllf=fx),
         timestamp=now_string(),
         # webview FitResults
         state=fit_state,

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1785,13 +1785,17 @@ def fit_result_summary(problem, results: OptimizeResult) -> dict:
     return summary
 
 
-def save_fit_result(problem, results: OptimizeResult, filename):
+def save_fit_result(problem, fit, filename):
     """
-    Save the :func:`fit_result_summary` of *results* to *filename* as JSON,
+    Save the :func:`fit_result_summary` of *fit* to *filename* as JSON,
     conventionally *<model>-fit.json* in the export directory.
+
+    *fit* may be an :class:`OptimizeResult` or a webview ``FitResult``; the
+    latter is converted to an :class:`OptimizeResult` for the summary.
     """
     from .dream.stats import numpy_json
 
+    results = fit if isinstance(fit, OptimizeResult) else _build_fit_result(problem, fit)
     with open(filename, "w") as fid:
         json.dump(fit_result_summary(problem, results), fid, default=numpy_json, sort_keys=True, indent=2)
 

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -2,6 +2,7 @@
 Interfaces to various optimizers.
 """
 
+import json
 import sys
 import warnings
 from time import perf_counter
@@ -1741,6 +1742,101 @@ def _build_fit_result(problem, webview_fit):
         options=webview_fit.options,
     )
     return results
+
+
+# OptimizeResult entries included in the exported fit results, where available.
+# The fitter state and the convergence history are excluded: the state is not
+# JSON serializable and the convergence history belongs with the plottable
+# outputs rather than the fit summary.
+_FIT_RESULT_EXPORT_FIELDS = (
+    "x",
+    "dx",
+    "fun",
+    "success",
+    "status",
+    "message",
+    "nit",
+    "nfev",
+    "dof",
+    "method",
+    "options",
+    "timestamp",
+)
+
+
+def fit_result_summary(problem, results: OptimizeResult) -> dict:
+    """
+    Return a JSON-serializable summary of the fit *results* for *problem*.
+
+    The summary contains the scipy-convention entries from *results* (x, dx,
+    fun, success, status, message, nit, ...) plus *labels* (the fitted
+    parameter labels, matching the order of x and dx), *points* (number of
+    data points) and *chisq* (normalized chi-squared at the best point, at
+    full precision). For a model with gaussian independent uncertainties the
+    raw sum of squares is chisq*dof.
+
+    The fitter state and the convergence history are not included.
+    """
+    summary = {key: results[key] for key in _FIT_RESULT_EXPORT_FIELDS if key in results}
+    summary["labels"] = problem.labels()
+    summary["points"] = problem.model_points()
+    # results.fun is the nllf at the best point; chisq(nllf=None) recomputes it
+    summary["chisq"] = problem.chisq(nllf=results.get("fun"))
+    return summary
+
+
+def save_fit_result(problem, results: OptimizeResult, filename):
+    """
+    Save the :func:`fit_result_summary` of *results* to *filename* as JSON,
+    conventionally *<model>-fit.json* in the export directory.
+    """
+    from .dream.stats import numpy_json
+
+    with open(filename, "w") as fid:
+        json.dump(fit_result_summary(problem, results), fid, default=numpy_json, sort_keys=True, indent=2)
+
+
+def test_fit_result_summary():
+    class _Problem:
+        dof = 8.0
+
+        def labels(self):
+            return ["P1", "P2"]
+
+        def chisq(self, nllf=None):
+            return 2 * nllf / self.dof
+
+        def model_points(self):
+            return 10
+
+    results = OptimizeResult(
+        x=np.array([1.0, 2.0]),
+        dx=np.array([0.1, 0.2]),
+        fun=20.0,
+        success=True,
+        status=0,
+        message="successful termination",
+        nit=100,
+        dof=8.0,
+        method="dream",
+        options={"samples": 100},
+        state=object(),  # not serializable; must be excluded
+        convergence=np.zeros((5, 6)),  # excluded
+    )
+    summary = fit_result_summary(_Problem(), results)
+    assert summary["labels"] == ["P1", "P2"]
+    assert summary["chisq"] == 5.0  # 2*20/8, full precision
+    assert summary["points"] == 10
+    assert summary["dof"] == 8.0
+    assert summary["method"] == "dream"
+    assert "state" not in summary
+    assert "convergence" not in summary
+    # the whole summary must survive a json round trip
+    from .dream.stats import numpy_json
+
+    data = json.loads(json.dumps(summary, default=numpy_json))
+    assert data["x"] == [1.0, 2.0]
+    assert data["dx"] == [0.1, 0.2]
 
 
 # TODO: Move simplified fit interface to its own file.

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -1855,7 +1855,10 @@ def fit(
     The keyword argments mostly follow the argument names used in the bumps
     command line interface. Try use *method=method* rather than *fit=method*)
 
-    Returns a scipy *OptimizeResult* object containing *x* and *dx*.  Some
+    Returns a scipy *OptimizeResult* object containing *x* and *dx*, plus
+    *labels* (the fitted parameter labels, matching the order of x and dx),
+    *numpoints* (number of data points) and *chisq* (normalized chi-squared
+    at the best point, at full precision). Some
     fitters also include a *result.state* object. For dream this can be used as
     *bumps.dream.views.plot_all(result.state)* to generate the uncertainty
     plots. Use *plot_convergence(result)* to show how the fit progressed.

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -53,7 +53,7 @@ import traceback
 import time
 
 from bumps.fitproblem import load_problem
-from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID, FIT_ACTIVE_IDS, _build_fit_result, save_fit_result
+from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID, FIT_ACTIVE_IDS, save_fit_result
 from bumps.mapper import MPMapper
 from bumps.parameter import Parameter, Constant, Variable, unique
 import bumps.fitproblem
@@ -536,8 +536,7 @@ def export_fit(
 
     # Write a machine-readable summary of the fit results.
     try:
-        results = fit if isinstance(fit, OptimizeResult) else _build_fit_result(problem, fit)
-        save_fit_result(problem, results, path / f"{basename}-fit.json")
+        save_fit_result(problem, fit, path / f"{basename}-fit.json")
     except Exception as exc:
         logger.error(f"Error writing {basename}-fit.json: {exc}")
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -53,7 +53,7 @@ import traceback
 import time
 
 from bumps.fitproblem import load_problem
-from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID, FIT_ACTIVE_IDS
+from bumps.fitters import FitDriver, OptimizeResult, FIT_DEFAULT_ID, FIT_ACTIVE_IDS, _build_fit_result, save_fit_result
 from bumps.mapper import MPMapper
 from bumps.parameter import Parameter, Constant, Variable, unique
 import bumps.fitproblem
@@ -533,6 +533,13 @@ def export_fit(
     # TODO: add fit method and options to the par file header
     # Write the pars file.
     _write_pars(problem, path, f"{basename}.par")
+
+    # Write a machine-readable summary of the fit results.
+    try:
+        results = fit if isinstance(fit, OptimizeResult) else _build_fit_result(problem, fit)
+        save_fit_result(problem, results, path / f"{basename}-fit.json")
+    except Exception as exc:
+        logger.error(f"Error writing {basename}-fit.json: {exc}")
 
     # Handle OptimizeResult or FitResult
     fit_state = getattr(fit, "fit_state", getattr(fit, "state", None))


### PR DESCRIPTION
Closes #413.

*Reworked per review — the original version added chisq/dof/points to the dream `-err.json`; this version instead writes a separate `<model>-fit.json` for all fitters, leaving `-err.json` and `bumps.dream` untouched.*

## What's exported

`export_fit()` now writes `<basename>-fit.json` alongside the other artifacts — a machine-readable summary of the fit results built from the `OptimizeResult`:

| key | value |
|---|---|
| `x`, `dx` | best point and standard error (parallel arrays) |
| `labels` | fitted parameter labels, matching the order of `x`/`dx` |
| `fun` | nllf at the best point |
| `chisq` | normalized χ² at the best point, full precision |
| `dof`, `points` | degrees of freedom, number of data points |
| `method`, `options` | fitter id and options |
| `success`, `status`, `message`, `nit`, `timestamp` | scipy-convention status fields |

The raw sum of squares is recoverable as `chisq · dof`. The fitter state and convergence history are excluded (not JSON serializable / belong with the plottable outputs).

```json
{
  "chisq": 0.775470697827463,
  "dof": 18,
  "dx": [0.0368..., 0.2155...],
  "fun": 6.979236280447168,
  "labels": ["a", "b"],
  "message": "successful termination",
  "method": "amoeba",
  "nit": 44,
  "options": {},
  "points": 20,
  "status": 0,
  "success": true,
  "timestamp": "1781054396.839657",
  "x": [2.5241..., 1.1630...]
}
```

## Design

- New `fitters.fit_result_summary(problem, results)` builds the JSON-serializable dict (whitelisted `OptimizeResult` fields + labels/points/chisq); `fitters.save_fit_result()` writes it. Both live next to `_build_fit_result`.
- `export_fit()` normalizes its `fit` argument: an `OptimizeResult` is used directly (scripting `fit(export=...)` path), a webview `FitResult` goes through `_build_fit_result(problem, fit)` (GUI export and CLI reload paths). One hook covers all fitters and all entry routes.
- `chisq` is computed from `results.fun` via `problem.chisq(nllf=...)`, so the model is not re-evaluated and the value matches `chisq_str` unrounded.
- Note: `dx` comes from the curvature (`problem.cov`) per `_build_fit_result`, so for DREAM it differs from the posterior `std` in `-err.json` — the two files report different (both meaningful) uncertainties.
- `std_scaled` from the previous version is dropped pending the broader decision on scaled χ² handling; with `chisq` and the uncertainties both machine-readable, users can apply `std·√χ²` themselves in the meantime.

## Testing

- `test_fit_result_summary` (fitters.py): summary contents, label/chisq/points math, exclusion of `state`/`convergence`, JSON round-trip — no filesystem needed.
- End-to-end: amoeba fit via `fit(problem, export=...)` and a DREAM fit via `export_fit()` with a webview `FitResult` both produce correct `-fit.json`; the DREAM `-err.json` output is byte-format identical to master.
- pytest on touched modules passes; ruff check/format clean on the diff (no new findings vs master).