### PR TITLE
API call for setting up a warm start based on current state

### DIFF
--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -299,6 +299,13 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
         # This can happen when a fit is aborted, new data is added to the model, and the fit is resumed.
         # The fit can also be resumed if there are changes to the model code or the constraints as long
         # the list of fit parameters is the same.
+        # Recompute logp for every chain head on the new likelihood surface before
+        # the Metropolis loop starts.  Without this, stale logp values from the
+        # previous fit (which may be much higher or lower under the new data) are
+        # used as the acceptance baseline, causing all new proposals to be either
+        # universally accepted or universally rejected and freezing the chain.
+        logp = dream.model.map(x)
+        state._gen_current_logp[:] = logp
         if state._best_x is not None:
             state._best_logp = float(dream.model.map(state._best_x[None, :])[0])
     else:

--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -295,9 +295,10 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
     previous_draws = state.draws
     if previous_draws:
         x, logp = state._last_gen()
-        x = x.copy()
-        logp = dream.model.map(x)
-        state._gen_current_logp[:] = logp
+        # Recalculating the likelihood at the start of resume in case the model definition has changed.
+        # This can happen when a fit is aborted, new data is added to the model, and the fit is resumed.
+        # The fit can also be resumed if there are changes to the model code or the constraints as long
+        # the list of fit parameters is the same.
         if state._best_x is not None:
             state._best_logp = float(dream.model.map(state._best_x[None, :])[0])
     else:
@@ -332,7 +333,7 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
 
     # frame = 0  # For debugging...
     next_outlier_test = max(state.Ngen, 2 * state.Ngen - 10)
-    next_convergence_test = state.generation + state.Ngen if previous_draws else state.Ngen
+    next_convergence_test = state.generation + state.Ngen
     final_gen = dream.draws + dream.burn
     # print(f"running dream with {dream.draws} draws and {dream.burn} burn; final gen={final_gen} draws={state.draws} gen={state.generation}")
     while state.draws < final_gen:

--- a/bumps/dream/core.py
+++ b/bumps/dream/core.py
@@ -295,6 +295,11 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
     previous_draws = state.draws
     if previous_draws:
         x, logp = state._last_gen()
+        x = x.copy()
+        logp = dream.model.map(x)
+        state._gen_current_logp[:] = logp
+        if state._best_x is not None:
+            state._best_logp = float(dream.model.map(state._best_x[None, :])[0])
     else:
         # No initial state, so evaluate initial population
         for x in dream.population:
@@ -327,7 +332,7 @@ def _run_dream(dream: Dream, abort_test=lambda: False):
 
     # frame = 0  # For debugging...
     next_outlier_test = max(state.Ngen, 2 * state.Ngen - 10)
-    next_convergence_test = state.Ngen
+    next_convergence_test = state.generation + state.Ngen if previous_draws else state.Ngen
     final_gen = dream.draws + dream.burn
     # print(f"running dream with {dream.draws} draws and {dream.burn} burn; final gen={final_gen} draws={state.draws} gen={state.generation}")
     while state.draws < final_gen:

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -886,51 +886,30 @@ class DreamModel:
         return -np.array(self.mapper(pop))
 
 
-def _rebuild_mcmc_state(old_fit_state, fitProblem, options: dict):
-    """Build a minimal MCMCDraw for a parameter-space change (add/remove/reorder).
+def map_labels(labels: list, old_labels: list) -> list:
+    """Return (new_index, old_index) pairs for every label in *labels* that also
+    appears in *old_labels*.
 
-    Uses ``initpop.generate`` with the stored fit options to produce a
-    correctly-sized population for the new problem (same pop scaling and init
-    strategy as DreamFit.solve).  Matched parameters have their columns
-    overwritten with old chain-head values; new parameters keep generated values.
+    Duplicates are matched in order: the first occurrence of a value in *labels*
+    maps to the first unused occurrence in *old_labels*, the second to the second,
+    and so on.
 
-    Returns a new MCMCDraw with ``draws=new_Npop`` so that ``_run_dream`` enters
-    the resume path, triggering nllf recompute and convergence delay.
+    # TODO: Use map_labels() to simplify fitproblem.load_pars()
     """
-    from .dream.state import MCMCDraw
+    from collections import defaultdict
 
-    old_labels = old_fit_state.labels
-    new_labels = fitProblem.labels()
-    old_x, _ = old_fit_state._last_gen()  # (old_Npop, old_Nvar)
+    # Build a list of old positions for each label (to handle duplicates).
+    idx_map: defaultdict = defaultdict(list)
+    for j, s in enumerate(old_labels):
+        idx_map[s].append(j)
 
-    # generate() handles pop scaling, init strategy, bounds, and use_point.
-    new_pop = initpop.generate(fitProblem, **options)  # (new_Npop, new_Nvar)
-    new_Npop, new_Nvar = new_pop.shape
+    pairs = []
+    for i, s in enumerate(labels):
+        if idx_map[s]:
+            j = idx_map[s].pop(0)
+            pairs.append((i, j))
 
-    # Override columns for parameters that survived from the old chain.
-    # np.resize tiles old rows to fill new_Npop.  Duplicated rows diverge quickly
-    # via DE perturbations; this is preferable to cold random draws from generate().
-    old_label_to_col = {label: i for i, label in enumerate(old_labels)}
-    old_x_resized = np.resize(old_x, (new_Npop, old_x.shape[1]))
-    for new_col, label in enumerate(new_labels):
-        if label in old_label_to_col:
-            new_pop[:, new_col] = old_x_resized[:, old_label_to_col[label]]
-
-    Ncr = old_fit_state.Ncr
-    thinning = old_fit_state.thinning
-    new_state = MCMCDraw(1, 1, 1, new_Nvar, new_Npop, Ncr, thinning)
-    new_state._gen_current[:] = new_pop
-    # -inf logp causes metropolis to accept all proposals on the first DE step,
-    # ensuring real logp values are recorded before _best_x is needed by the monitor.
-    new_state._gen_current_logp[:] = -np.inf
-    # Guarantee state.best() returns a valid array immediately.
-    new_state._best_x = new_pop[0].copy()
-    new_state._best_logp = -np.inf
-    new_state.labels = new_labels
-    # draws=new_Npop > 0 makes previous_draws truthy in _run_dream
-    new_state.draws = new_Npop
-    new_state.generation = 1
-    return new_state
+    return pairs
 
 
 class DreamFit(FitBase):
@@ -965,19 +944,29 @@ class DreamFit(FitBase):
             monitors(step=step, point=x, value=-fx, population_points=pop, population_values=-logp)
             return True
 
-        population = initpop.generate(self.problem, **options)
+        if self.state is not None and hasattr(self.state, "labels"):
+            # Number of chains can't change on resume, so ignore pop option and
+            # use the existing chain count (negative pop = absolute count in generate).
+            population = initpop.generate(self.problem, init=options["init"], pop=-self.state.Npop)
+            labels, old_labels = self.problem.labels(), self.state.labels
+            if labels != old_labels:
+                # Parameter space changed (add/remove/reorder).  Seed matched
+                # columns from chain heads, then discard the old state so
+                # _run_dream starts fresh without an incompatible history buffer.
+                pairs = map_labels(labels, old_labels)
+                if pairs:
+                    new_index, old_index = zip(*pairs)
+                    old_population, _ = self.state._last_gen()
+                    population[:, list(new_index)] = old_population[:, list(old_index)]
+                self.state = None
+        else:
+            population = initpop.generate(self.problem, **options)
+
         pop_size = population.shape[0]
         draws, steps = int(options["samples"]), options["steps"]
         if steps == 0:
             steps = (draws + pop_size - 1) // pop_size
         monitors.info(f"# burn: {options['burn']} # steps: {steps}, # draws: {pop_size * steps}")
-
-        # On resume, if the parameter space changed (add/remove/reorder) rebuild the
-        # chain state so _run_dream enters the resume path (nllf recompute + convergence
-        # delay) rather than starting cold.
-        if self.state is not None and hasattr(self.state, "labels"):
-            if self.state.labels != self.problem.labels():
-                self.state = _rebuild_mcmc_state(self.state, self.problem, options)
 
         population = population[None, :, :]
         # print(f"Running dream with {population.shape=} {pop_size=} {steps=}")

--- a/bumps/fitters.py
+++ b/bumps/fitters.py
@@ -886,6 +886,53 @@ class DreamModel:
         return -np.array(self.mapper(pop))
 
 
+def _rebuild_mcmc_state(old_fit_state, fitProblem, options: dict):
+    """Build a minimal MCMCDraw for a parameter-space change (add/remove/reorder).
+
+    Uses ``initpop.generate`` with the stored fit options to produce a
+    correctly-sized population for the new problem (same pop scaling and init
+    strategy as DreamFit.solve).  Matched parameters have their columns
+    overwritten with old chain-head values; new parameters keep generated values.
+
+    Returns a new MCMCDraw with ``draws=new_Npop`` so that ``_run_dream`` enters
+    the resume path, triggering nllf recompute and convergence delay.
+    """
+    from .dream.state import MCMCDraw
+
+    old_labels = old_fit_state.labels
+    new_labels = fitProblem.labels()
+    old_x, _ = old_fit_state._last_gen()  # (old_Npop, old_Nvar)
+
+    # generate() handles pop scaling, init strategy, bounds, and use_point.
+    new_pop = initpop.generate(fitProblem, **options)  # (new_Npop, new_Nvar)
+    new_Npop, new_Nvar = new_pop.shape
+
+    # Override columns for parameters that survived from the old chain.
+    # np.resize tiles old rows to fill new_Npop.  Duplicated rows diverge quickly
+    # via DE perturbations; this is preferable to cold random draws from generate().
+    old_label_to_col = {label: i for i, label in enumerate(old_labels)}
+    old_x_resized = np.resize(old_x, (new_Npop, old_x.shape[1]))
+    for new_col, label in enumerate(new_labels):
+        if label in old_label_to_col:
+            new_pop[:, new_col] = old_x_resized[:, old_label_to_col[label]]
+
+    Ncr = old_fit_state.Ncr
+    thinning = old_fit_state.thinning
+    new_state = MCMCDraw(1, 1, 1, new_Nvar, new_Npop, Ncr, thinning)
+    new_state._gen_current[:] = new_pop
+    # -inf logp causes metropolis to accept all proposals on the first DE step,
+    # ensuring real logp values are recorded before _best_x is needed by the monitor.
+    new_state._gen_current_logp[:] = -np.inf
+    # Guarantee state.best() returns a valid array immediately.
+    new_state._best_x = new_pop[0].copy()
+    new_state._best_logp = -np.inf
+    new_state.labels = new_labels
+    # draws=new_Npop > 0 makes previous_draws truthy in _run_dream
+    new_state.draws = new_Npop
+    new_state.generation = 1
+    return new_state
+
+
 class DreamFit(FitBase):
     name = "DREAM"
     id = "dream"
@@ -924,6 +971,14 @@ class DreamFit(FitBase):
         if steps == 0:
             steps = (draws + pop_size - 1) // pop_size
         monitors.info(f"# burn: {options['burn']} # steps: {steps}, # draws: {pop_size * steps}")
+
+        # On resume, if the parameter space changed (add/remove/reorder) rebuild the
+        # chain state so _run_dream enters the resume path (nllf recompute + convergence
+        # delay) rather than starting cold.
+        if self.state is not None and hasattr(self.state, "labels"):
+            if self.state.labels != self.problem.labels():
+                self.state = _rebuild_mcmc_state(self.state, self.problem, options)
+
         population = population[None, :, :]
         # print(f"Running dream with {population.shape=} {pop_size=} {steps=}")
         sampler = Dream(

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -427,7 +427,7 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
 
 
 @register
-async def warm_start(
+async def prepare_warm_start(
     serialized: str,
     method: str = "dataclass",
     name: Optional[str] = None,

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -427,44 +427,37 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
 
 
 @register
-async def prepare_warm_start(
+async def replace_serialized_problem(
     serialized: str,
     method: str = "dataclass",
     name: Optional[str] = None,
 ):
-    """Inject a new FitProblem and prepare the server for a warm-start DREAM fit.
+    """Replace the current FitProblem without resetting the fit state.
 
-    Replaces the current FitProblem (e.g. one with an additional data point)
-    while retaining only the DREAM chain heads from the existing fit state —
-    discarding the thinned sample history, convergence data, and any stale
-    log-probability values.  The next ``start_fit_thread("dream", options,
-    resume=True)`` call will seed the chain population from those heads rather
-    than drawing a fresh initial population, substantially reducing burn-in
-    cost in autonomous measurement loops.
-
-    The degrees of freedom are recomputed automatically from the new problem
-    (via ``model_reset()`` inside deserialization), so adding data points does
-    not require any manual dof update.
+    Use this instead of ``set_serialized_problem`` when the new problem has the
+    same parameter space as the current one (e.g. an additional data point has
+    been added) and you want to resume DREAM from the existing chain population
+    rather than starting fresh.  On the next
+    ``start_fit_thread("dream", options, resume=True)`` call, ``_run_dream``
+    will recompute nllf for all chain heads and the stored best point on the
+    new likelihood surface, and will defer the convergence test by one full
+    buffer cycle so stale samples are flushed before convergence is checked.
 
     Raises ``ValueError`` if the number of free parameters in *serialized*
-    differs from the current chain state — chain heads are meaningless for a
-    different parameter space and a cold start via ``set_serialized_problem``
-    is required instead.
+    differs from the current chain state — the chain is meaningless for a
+    different parameter space; use ``set_serialized_problem()`` for a cold
+    start in that case.
 
     The *method* parameter accepts ``"dataclass"`` (default, safe),
     ``"pickle"``, ``"cloudpickle"``, or ``"dill"``.  The latter three enable
     arbitrary code execution and carry the same caveat as
     ``set_serialized_problem``.
     """
-    import numpy as _np
-    from bumps.dream.state import MCMCDraw
-
     # Deserialize the new problem first so we fail fast on bad input.
     fitProblem = deserialize_problem(serialized, method=method)
 
-    # Extract chain heads from the current fit state before replacing anything.
+    # Validate parameter count against the current chain state.
     fit_state = state.fitting.fit_state
-    heads = heads_logp = fitter_method = None
     if fit_state is not None and hasattr(fit_state, "Nvar"):
         new_nvar = len(fitProblem.getp())
         if new_nvar != fit_state.Nvar:
@@ -473,40 +466,14 @@ async def prepare_warm_start(
                 f"but the current chain state has {fit_state.Nvar}. "
                 f"Call set_serialized_problem() to start a fresh fit."
             )
-        heads, heads_logp = fit_state._last_gen()
-        heads = heads.copy()
-        heads_logp = heads_logp.copy()
-        Nvar = fit_state.Nvar
-        Npop = fit_state.Npop
-        Ncr = fit_state.Ncr
-        fitter_method = state.fitting.method or "dream"
 
-    # Install the new problem.
+    # Install the new problem; the existing fit_state is preserved intact.
+    # _run_dream recomputes nllf on resume, so stale logp values are not a concern.
     state.problem.fitProblem = fitProblem
     if name:
         fitProblem.name = name
     state.shared.updated_model = now_string()
     state.shared.updated_parameters = now_string()
-
-    # Replace fit_state with a minimal MCMCDraw carrying only the chain heads.
-    # Discarding the thinned history keeps the state small and avoids stale
-    # log-probability values from the old likelihood surface contaminating
-    # best-point tracking on the new problem.
-    if heads is not None:
-        new_fit_state = MCMCDraw(1, 1, 1, Nvar, Npop, Ncr, 1)
-        new_fit_state._gen_current[:] = heads
-        new_fit_state._gen_current_logp[:] = heads_logp
-        # draws=Npop / generation=1: triggers the warm-start path in core.py
-        # (`if previous_draws: x, logp = state._last_gen()`) while leaving
-        # the full new sample budget available.
-        new_fit_state.draws = Npop
-        new_fit_state.generation = 1
-        # _best_logp from the old run is incommensurable with the new
-        # likelihood surface — reset so any new sample can claim the best.
-        new_fit_state._best_x = None
-        new_fit_state._best_logp = -_np.inf
-        state.set_fit_state(new_fit_state, method=fitter_method)
-        state.fitting.method = fitter_method
 
     state.autosave()
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -478,6 +478,7 @@ async def prepare_warm_start(
         heads_logp = heads_logp.copy()
         Nvar = fit_state.Nvar
         Npop = fit_state.Npop
+        Ncr = fit_state.Ncr
         fitter_method = state.fitting.method or "dream"
 
     # Install the new problem.
@@ -492,7 +493,6 @@ async def prepare_warm_start(
     # log-probability values from the old likelihood surface contaminating
     # best-point tracking on the new problem.
     if heads is not None:
-        Ncr = 3  # AdaptiveCrossover default; resize() will correct if needed
         new_fit_state = MCMCDraw(1, 1, 1, Nvar, Npop, Ncr, 1)
         new_fit_state._gen_current[:] = heads
         new_fit_state._gen_current_logp[:] = heads_logp

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -427,12 +427,12 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
 
 
 @register
-async def replace_serialized_problem(
+async def update_serialized_problem(
     serialized: str,
     method: str = "dataclass",
     name: Optional[str] = None,
 ):
-    """Replace the current FitProblem without resetting the fit state.
+    """Update the current FitProblem without resetting the fit state.
 
     Use this instead of ``set_serialized_problem`` when the new problem has the
     same parameter space as the current one (e.g. an additional data point has
@@ -443,10 +443,9 @@ async def replace_serialized_problem(
     new likelihood surface, and will defer the convergence test by one full
     buffer cycle so stale samples are flushed before convergence is checked.
 
-    Raises ``ValueError`` if the number of free parameters in *serialized*
-    differs from the current chain state — the chain is meaningless for a
-    different parameter space; use ``set_serialized_problem()`` for a cold
-    start in that case.
+    Raises ``ValueError`` if the parameter labels in *serialized* differ from
+    the current chain state — the chain is meaningless for a different parameter
+    space; use ``set_serialized_problem()`` for a cold start in that case.
 
     The *method* parameter accepts ``"dataclass"`` (default, safe),
     ``"pickle"``, ``"cloudpickle"``, or ``"dill"``.  The latter three enable
@@ -456,14 +455,15 @@ async def replace_serialized_problem(
     # Deserialize the new problem first so we fail fast on bad input.
     fitProblem = deserialize_problem(serialized, method=method)
 
-    # Validate parameter count against the current chain state.
+    # Validate parameter labels against the current chain state.
+    # Comparing labels is robust against adding, removing, or reordering parameters.
     fit_state = state.fitting.fit_state
-    if fit_state is not None and hasattr(fit_state, "Nvar"):
-        new_nvar = len(fitProblem.getp())
-        if new_nvar != fit_state.Nvar:
+    if fit_state is not None and hasattr(fit_state, "labels"):
+        new_labels = fitProblem.labels()
+        if fit_state.labels != new_labels:
             raise ValueError(
-                f"Cannot warm-start: new problem has {new_nvar} free parameters "
-                f"but the current chain state has {fit_state.Nvar}. "
+                f"Cannot warm-start: parameter labels have changed. "
+                f"Old: {fit_state.labels}. New: {new_labels}. "
                 f"Call set_serialized_problem() to start a fresh fit."
             )
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -420,10 +420,200 @@ async def get_session():
 
 
 @register
+async def get_fit_state_heads() -> Optional[str]:
+    """Return a base64-encoded minimal HDF5 blob containing only the DREAM
+    chain heads (current population positions and log-probabilities).
+
+    Unlike *get_session* or extracting the full *fit_state*, this payload is
+    tiny: two arrays of shape ``(Npop, Nvar)`` and ``(Npop,)`` plus the fitter
+    method string.  For 40 parameters and pop=10 that is roughly 3 KB — well
+    within socket.io's default message limit regardless of how many MCMC
+    samples have been collected.
+
+    The returned string can be passed directly to *load_fit_state_heads* on
+    the next iteration to warm-start the chain.
+    """
+    import io as _io
+    import base64 as _base64
+    import h5py as _h5py
+    import numpy as _np
+
+    fitting = state.fitting
+    if fitting is None or fitting.fit_state is None:
+        return None
+
+    fs = fitting.fit_state
+    heads, heads_logp = fs._last_gen()
+
+    bio = _io.BytesIO()
+    with _h5py.File(bio, "w") as f:
+        g = f.require_group("fit_state_heads")
+        g.create_dataset("current_population", data=heads, compression=9)
+        g.create_dataset("current_logp", data=heads_logp, compression=9)
+        g.attrs["method"] = fitting.method or "dream"
+        g.attrs["Nvar"] = int(fs.Nvar)
+        g.attrs["Npop"] = int(fs.Npop)
+    return _base64.b64encode(bio.getvalue()).decode()
+
+
+@register
+async def load_fit_state_heads(heads_b64: str):
+    """Restore DREAM chain heads from a base64-encoded blob produced by
+    *get_fit_state_heads*.
+
+    This is the socket.io-native counterpart to *load_fit_state*: it accepts
+    only the chain-head arrays (not the full thinned history), so the payload
+    is always a few kilobytes and passes through socket.io without size issues.
+
+    After calling this, call *set_problem_keep_state* (to inject the updated
+    FitProblem) and then *start_fit_thread* with ``resume=True``.
+
+    Raises *ValueError* if the number of free parameters in the stored heads
+    differs from the current FitProblem — the chain heads would be invalid for
+    a different parameter space.
+    """
+    import io as _io
+    import base64 as _base64
+    import h5py as _h5py
+    import numpy as _np
+    from bumps.dream.state import MCMCDraw
+
+    bio = _io.BytesIO(_base64.b64decode(heads_b64))
+    with _h5py.File(bio, "r") as f:
+        g = f.get("fit_state_heads")
+        if g is None:
+            raise ValueError("Blob contains no fit_state_heads group")
+        heads = g["current_population"][:]
+        heads_logp = g["current_logp"][:]
+        method = g.attrs.get("method", "dream")
+        Nvar = int(g.attrs["Nvar"])
+        Npop = int(g.attrs["Npop"])
+
+    # Validate against current problem if one is loaded.
+    if state.problem is not None and state.problem.fitProblem is not None:
+        new_nvar = len(state.problem.fitProblem.getp())
+        if new_nvar != Nvar:
+            raise ValueError(
+                f"Chain heads have {Nvar} parameters but current problem has "
+                f"{new_nvar}. Use set_serialized_problem() to start a fresh fit."
+            )
+
+    # Build a minimal MCMCDraw that carries only the chain heads.
+    # Ngen=1, Nthin=1, Nupdate=1 keep memory negligible; DREAM will resize
+    # on the first call to allocate_state().
+    Ncr = 3  # AdaptiveCrossover default
+    fit_state = MCMCDraw(1, 1, 1, Nvar, Npop, Ncr, 1)
+    fit_state._gen_current[:] = heads
+    fit_state._gen_current_logp[:] = heads_logp
+    # One prior generation recorded so core.py warm-start path triggers.
+    fit_state.draws = Npop
+    fit_state.generation = 1
+    # Fresh best tracking — old logp is incommensurable with the new problem.
+    fit_state._best_x = None
+    fit_state._best_logp = -_np.inf
+
+    state.set_fit_state(fit_state, method=method)
+    state.fitting.method = method
+
+
+@register
 async def load_session(pathlist: List[str], filename: str, read_only: bool = False):
     state.setup_backing(filename, pathlist, read_only=read_only)
     state.shared.updated_model = now_string()
     state.shared.updated_parameters = now_string()
+
+
+@register
+async def load_fit_state(session_b64: str):
+    """Restore only the MCMC chain state from a base64-encoded HDF5 session blob.
+
+    Unlike *load_session*, this endpoint does **not** deserialise the stored
+    FitProblem, so it is safe to call with a session produced by a remote
+    server.  Only the fit_state (chain heads, thinned draws, CR weights, …)
+    and the fitter method name are extracted; everything else in the blob is
+    ignored.
+
+    Typical use: warm-start an autonomous measurement loop.  Call this first
+    to restore chain state from the previous iteration, then call
+    *set_problem_keep_state* to inject the updated FitProblem (with a new
+    data point added), then call *start_fit_thread* with ``resume=True``.
+    """
+    import io
+    import base64
+    import h5py
+    from bumps.dream.state import h5load
+    from .state_hdf5_backed import read_string, UNDEFINED
+
+    bio = io.BytesIO(base64.b64decode(session_b64))
+    with h5py.File(bio, "r") as f:
+        fitting_group = f.get("fitting")
+        if fitting_group is None or "fit_state" not in fitting_group:
+            raise ValueError("Session blob contains no fit_state")
+        _method = read_string(fitting_group, "method")
+        method = _method if isinstance(_method, str) else "dream"
+        fit_state = h5load(fitting_group["fit_state"])
+
+    # Reset draw counters so DREAM runs a full new set of samples from the
+    # chain heads.  h5load() sets draws = Ngen * Npop (the full prior run),
+    # which would immediately satisfy the stopping condition (draws >= budget)
+    # and cause DREAM to exit after zero iterations.
+    #
+    # Setting draws = Npop and generation = 1 leaves exactly one "prior
+    # generation" in the buffer, which is all the warm-start path needs:
+    # core.py checks `if previous_draws:` and calls state._last_gen() to
+    # seed chain heads rather than evaluating the initial population afresh.
+    fit_state.draws = fit_state.Npop
+    fit_state.generation = 1
+    # Reset best-point tracking.  _best_x / _best_logp are carried over from
+    # the prior run's likelihood surface.  With a different FitProblem (new
+    # data), those log-likelihood values are incommensurable with new draws, so
+    # new samples will never beat the stale _best_logp and setp() will keep the
+    # old parameter values forever.
+    import numpy as _np
+
+    fit_state._best_x = None
+    fit_state._best_logp = -_np.inf
+
+    state.set_fit_state(fit_state, method=method)
+    state.fitting.method = method
+
+
+@register
+async def set_problem_keep_state(
+    serialized: str,
+    method: str = "dataclass",
+    name: Optional[str] = None,
+):
+    """Replace the FitProblem without clearing the MCMC chain state.
+
+    This is the counterpart to *set_serialized_problem*: it swaps in a new
+    problem definition (e.g. one with an additional data point) while
+    preserving the existing *fit_state* so that the next *start_fit_thread*
+    call with ``resume=True`` warm-starts from the current chain heads rather
+    than drawing a fresh initial population.
+
+    Raises *ValueError* if the number of free parameters in *serialized*
+    differs from the dimensionality of the stored chain state — the chain
+    heads would be meaningless for a different parameter space.
+    """
+    fitProblem = deserialize_problem(serialized, method=method)
+
+    fit_state = state.fitting.fit_state
+    if fit_state is not None and hasattr(fit_state, "Nvar"):
+        new_nvar = len(fitProblem.getp())
+        if new_nvar != fit_state.Nvar:
+            raise ValueError(
+                f"Cannot keep chain state: new problem has {new_nvar} free "
+                f"parameters but the stored chain state has {fit_state.Nvar}. "
+                f"Call set_serialized_problem() to start a fresh fit."
+            )
+
+    state.problem.fitProblem = fitProblem
+    if name:
+        fitProblem.name = name
+    state.shared.updated_model = now_string()
+    state.shared.updated_parameters = now_string()
+    state.autosave()
 
 
 @register

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -426,6 +426,57 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
     state.shared.updated_parameters = now_string()
 
 
+def _rebuild_mcmc_state(old_fit_state: MCMCDraw, fitProblem, options: dict) -> MCMCDraw:
+    """Build a minimal MCMCDraw for a parameter space change (add/remove/reorder).
+
+    Uses ``bumps.initpop.generate`` with the stored fit options to produce a
+    correctly-sized population for the new problem (same pop scaling and init
+    strategy as DreamFit.solve).  Matched parameters then have their columns
+    overwritten with the old chain-head values.  New parameters keep the
+    generated values.
+
+    Returns a new MCMCDraw with draws=new_Npop so that _run_dream enters the
+    resume path, triggering nllf recompute and convergence delay.
+    """
+    from bumps.initpop import generate
+
+    old_labels = old_fit_state.labels
+    new_labels = fitProblem.labels()
+    old_x, _ = old_fit_state._last_gen()  # (old_Npop, old_Nvar)
+
+    # generate() handles pop scaling, init strategy, bounds, and use_point.
+    new_pop = generate(fitProblem, **options)  # (new_Npop, new_Nvar)
+    new_Npop, new_Nvar = new_pop.shape
+
+    # Override columns for parameters that survived from the old chain.
+    # np.resize tiles old rows to fill new_Npop (which may be larger, e.g. going
+    # from 1 to 2 parameters doubles the required population).  Duplicated rows
+    # diverge quickly via DE perturbations; this is preferable to leaving the
+    # extra rows as cold random draws from generate(), which would drag convergence.
+    old_label_to_col = {label: i for i, label in enumerate(old_labels)}
+    old_x_resized = np.resize(old_x, (new_Npop, old_x.shape[1]))
+    for new_col, label in enumerate(new_labels):
+        if label in old_label_to_col:
+            new_pop[:, new_col] = old_x_resized[:, old_label_to_col[label]]
+
+    Ncr = old_fit_state.Ncr
+    thinning = old_fit_state.thinning
+    new_state = MCMCDraw(1, 1, 1, new_Nvar, new_Npop, Ncr, thinning)
+    new_state._gen_current[:] = new_pop
+    # -inf logp_old causes metropolis to accept all proposals on the first DE step,
+    # ensuring real logp values are recorded before _best_x is needed by the monitor.
+    new_state._gen_current_logp[:] = -np.inf
+    # Guarantee state.best() returns a valid array; also lets _run_dream's nllf
+    # recompute at the top of the resume path evaluate a sensible starting point.
+    new_state._best_x = new_pop[0].copy()
+    new_state._best_logp = -np.inf
+    new_state.labels = new_labels
+    # draws=new_Npop > 0 makes previous_draws truthy in _run_dream
+    new_state.draws = new_Npop
+    new_state.generation = 1
+    return new_state
+
+
 @register
 async def update_serialized_problem(
     serialized: str,
@@ -434,18 +485,19 @@ async def update_serialized_problem(
 ):
     """Update the current FitProblem without resetting the fit state.
 
-    Use this instead of ``set_serialized_problem`` when the new problem has the
-    same parameter space as the current one (e.g. an additional data point has
-    been added) and you want to resume DREAM from the existing chain population
-    rather than starting fresh.  On the next
-    ``start_fit_thread("dream", options, resume=True)`` call, ``_run_dream``
-    will recompute nllf for all chain heads and the stored best point on the
-    new likelihood surface, and will defer the convergence test by one full
-    buffer cycle so stale samples are flushed before convergence is checked.
+    Use this instead of ``set_serialized_problem`` when you want to resume
+    DREAM from the existing chain population rather than starting fresh.  On
+    the next ``start_fit_thread("dream", options, resume=True)`` call,
+    ``_run_dream`` will recompute nllf for all chain heads on the new
+    likelihood surface and defer the convergence test by one full buffer cycle.
 
-    Raises ``ValueError`` if the parameter labels in *serialized* differ from
-    the current chain state — the chain is meaningless for a different parameter
-    space; use ``set_serialized_problem()`` for a cold start in that case.
+    If the parameter labels are identical to the current chain state the full
+    chain history is preserved.  If labels have changed (parameters added,
+    removed, or renamed) a minimal MCMCDraw is built: matched parameters carry
+    their chain-head values forward; new parameters are seeded with LHS draws.
+    History is lost in this case but a cold start is avoided.
+
+    Use ``set_serialized_problem()`` for a true cold start.
 
     The *method* parameter accepts ``"dataclass"`` (default, safe),
     ``"pickle"``, ``"cloudpickle"``, or ``"dill"``.  The latter three enable
@@ -455,20 +507,16 @@ async def update_serialized_problem(
     # Deserialize the new problem first so we fail fast on bad input.
     fitProblem = deserialize_problem(serialized, method=method)
 
-    # Validate parameter labels against the current chain state.
-    # Comparing labels is robust against adding, removing, or reordering parameters.
     fit_state = state.fitting.fit_state
     if fit_state is not None and hasattr(fit_state, "labels"):
         new_labels = fitProblem.labels()
         if fit_state.labels != new_labels:
-            raise ValueError(
-                f"Cannot warm-start: parameter labels have changed. "
-                f"Old: {fit_state.labels}. New: {new_labels}. "
-                f"Call set_serialized_problem() to start a fresh fit."
-            )
+            # Parameter space has changed — rebuild a minimal MCMCDraw so that
+            # _run_dream still enters the resume path (nllf recompute + convergence delay).
+            new_fit_state = _rebuild_mcmc_state(fit_state, fitProblem, options=state.fitting.options)
+            state.set_fit_state(new_fit_state, method=state.fitting.method)
 
-    # Install the new problem; the existing fit_state is preserved intact.
-    # _run_dream recomputes nllf on resume, so stale logp values are not a concern.
+    # Install the new problem; the existing (or rebuilt) fit_state is preserved.
     state.problem.fitProblem = fitProblem
     if name:
         fitProblem.name = name

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -420,103 +420,6 @@ async def get_session():
 
 
 @register
-async def get_fit_state_heads() -> Optional[str]:
-    """Return a base64-encoded minimal HDF5 blob containing only the DREAM
-    chain heads (current population positions and log-probabilities).
-
-    Unlike *get_session* or extracting the full *fit_state*, this payload is
-    tiny: two arrays of shape ``(Npop, Nvar)`` and ``(Npop,)`` plus the fitter
-    method string.  For 40 parameters and pop=10 that is roughly 3 KB — well
-    within socket.io's default message limit regardless of how many MCMC
-    samples have been collected.
-
-    The returned string can be passed directly to *load_fit_state_heads* on
-    the next iteration to warm-start the chain.
-    """
-    import io as _io
-    import base64 as _base64
-    import h5py as _h5py
-    import numpy as _np
-
-    fitting = state.fitting
-    if fitting is None or fitting.fit_state is None:
-        return None
-
-    fs = fitting.fit_state
-    heads, heads_logp = fs._last_gen()
-
-    bio = _io.BytesIO()
-    with _h5py.File(bio, "w") as f:
-        g = f.require_group("fit_state_heads")
-        g.create_dataset("current_population", data=heads, compression=9)
-        g.create_dataset("current_logp", data=heads_logp, compression=9)
-        g.attrs["method"] = fitting.method or "dream"
-        g.attrs["Nvar"] = int(fs.Nvar)
-        g.attrs["Npop"] = int(fs.Npop)
-    return _base64.b64encode(bio.getvalue()).decode()
-
-
-@register
-async def load_fit_state_heads(heads_b64: str):
-    """Restore DREAM chain heads from a base64-encoded blob produced by
-    *get_fit_state_heads*.
-
-    This is the socket.io-native counterpart to *load_fit_state*: it accepts
-    only the chain-head arrays (not the full thinned history), so the payload
-    is always a few kilobytes and passes through socket.io without size issues.
-
-    After calling this, call *set_problem_keep_state* (to inject the updated
-    FitProblem) and then *start_fit_thread* with ``resume=True``.
-
-    Raises *ValueError* if the number of free parameters in the stored heads
-    differs from the current FitProblem — the chain heads would be invalid for
-    a different parameter space.
-    """
-    import io as _io
-    import base64 as _base64
-    import h5py as _h5py
-    import numpy as _np
-    from bumps.dream.state import MCMCDraw
-
-    bio = _io.BytesIO(_base64.b64decode(heads_b64))
-    with _h5py.File(bio, "r") as f:
-        g = f.get("fit_state_heads")
-        if g is None:
-            raise ValueError("Blob contains no fit_state_heads group")
-        heads = g["current_population"][:]
-        heads_logp = g["current_logp"][:]
-        method = g.attrs.get("method", "dream")
-        Nvar = int(g.attrs["Nvar"])
-        Npop = int(g.attrs["Npop"])
-
-    # Validate against current problem if one is loaded.
-    if state.problem is not None and state.problem.fitProblem is not None:
-        new_nvar = len(state.problem.fitProblem.getp())
-        if new_nvar != Nvar:
-            raise ValueError(
-                f"Chain heads have {Nvar} parameters but current problem has "
-                f"{new_nvar}. Use set_serialized_problem() to start a fresh fit."
-            )
-
-    # Build a minimal MCMCDraw that carries only the chain heads.
-    # Ngen=1, Nthin=1, Nupdate=1 keep memory negligible; DREAM will resize
-    # on the first call to allocate_state().
-    Ncr = 3  # AdaptiveCrossover default
-    fit_state = MCMCDraw(1, 1, 1, Nvar, Npop, Ncr, 1)
-    fit_state._gen_current[:] = heads
-    fit_state._gen_current_logp[:] = heads_logp
-    # One prior generation recorded so core.py warm-start path triggers.
-    fit_state.draws = Npop
-    fit_state.generation = 1
-    # Fresh best tracking — old logp is incommensurable with the new problem.
-    fit_state._best_x = None
-    fit_state._best_logp = -_np.inf
-
-    state.set_fit_state(fit_state, method=method)
-    state.fitting.method = method
-
-
-@register
 async def load_session(pathlist: List[str], filename: str, read_only: bool = False):
     state.setup_backing(filename, pathlist, read_only=read_only)
     state.shared.updated_model = now_string()
@@ -524,95 +427,87 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
 
 
 @register
-async def load_fit_state(session_b64: str):
-    """Restore only the MCMC chain state from a base64-encoded HDF5 session blob.
-
-    Unlike *load_session*, this endpoint does **not** deserialise the stored
-    FitProblem, so it is safe to call with a session produced by a remote
-    server.  Only the fit_state (chain heads, thinned draws, CR weights, …)
-    and the fitter method name are extracted; everything else in the blob is
-    ignored.
-
-    Typical use: warm-start an autonomous measurement loop.  Call this first
-    to restore chain state from the previous iteration, then call
-    *set_problem_keep_state* to inject the updated FitProblem (with a new
-    data point added), then call *start_fit_thread* with ``resume=True``.
-    """
-    import io
-    import base64
-    import h5py
-    from bumps.dream.state import h5load
-    from .state_hdf5_backed import read_string, UNDEFINED
-
-    bio = io.BytesIO(base64.b64decode(session_b64))
-    with h5py.File(bio, "r") as f:
-        fitting_group = f.get("fitting")
-        if fitting_group is None or "fit_state" not in fitting_group:
-            raise ValueError("Session blob contains no fit_state")
-        _method = read_string(fitting_group, "method")
-        method = _method if isinstance(_method, str) else "dream"
-        fit_state = h5load(fitting_group["fit_state"])
-
-    # Reset draw counters so DREAM runs a full new set of samples from the
-    # chain heads.  h5load() sets draws = Ngen * Npop (the full prior run),
-    # which would immediately satisfy the stopping condition (draws >= budget)
-    # and cause DREAM to exit after zero iterations.
-    #
-    # Setting draws = Npop and generation = 1 leaves exactly one "prior
-    # generation" in the buffer, which is all the warm-start path needs:
-    # core.py checks `if previous_draws:` and calls state._last_gen() to
-    # seed chain heads rather than evaluating the initial population afresh.
-    fit_state.draws = fit_state.Npop
-    fit_state.generation = 1
-    # Reset best-point tracking.  _best_x / _best_logp are carried over from
-    # the prior run's likelihood surface.  With a different FitProblem (new
-    # data), those log-likelihood values are incommensurable with new draws, so
-    # new samples will never beat the stale _best_logp and setp() will keep the
-    # old parameter values forever.
-    import numpy as _np
-
-    fit_state._best_x = None
-    fit_state._best_logp = -_np.inf
-
-    state.set_fit_state(fit_state, method=method)
-    state.fitting.method = method
-
-
-@register
-async def set_problem_keep_state(
+async def warm_start(
     serialized: str,
     method: str = "dataclass",
     name: Optional[str] = None,
 ):
-    """Replace the FitProblem without clearing the MCMC chain state.
+    """Inject a new FitProblem and prepare the server for a warm-start DREAM fit.
 
-    This is the counterpart to *set_serialized_problem*: it swaps in a new
-    problem definition (e.g. one with an additional data point) while
-    preserving the existing *fit_state* so that the next *start_fit_thread*
-    call with ``resume=True`` warm-starts from the current chain heads rather
-    than drawing a fresh initial population.
+    Replaces the current FitProblem (e.g. one with an additional data point)
+    while retaining only the DREAM chain heads from the existing fit state —
+    discarding the thinned sample history, convergence data, and any stale
+    log-probability values.  The next ``start_fit_thread("dream", options,
+    resume=True)`` call will seed the chain population from those heads rather
+    than drawing a fresh initial population, substantially reducing burn-in
+    cost in autonomous measurement loops.
 
-    Raises *ValueError* if the number of free parameters in *serialized*
-    differs from the dimensionality of the stored chain state — the chain
-    heads would be meaningless for a different parameter space.
+    The degrees of freedom are recomputed automatically from the new problem
+    (via ``model_reset()`` inside deserialization), so adding data points does
+    not require any manual dof update.
+
+    Raises ``ValueError`` if the number of free parameters in *serialized*
+    differs from the current chain state — chain heads are meaningless for a
+    different parameter space and a cold start via ``set_serialized_problem``
+    is required instead.
+
+    The *method* parameter accepts ``"dataclass"`` (default, safe),
+    ``"pickle"``, ``"cloudpickle"``, or ``"dill"``.  The latter three enable
+    arbitrary code execution and carry the same caveat as
+    ``set_serialized_problem``.
     """
+    import numpy as _np
+    from bumps.dream.state import MCMCDraw
+
+    # Deserialize the new problem first so we fail fast on bad input.
     fitProblem = deserialize_problem(serialized, method=method)
 
+    # Extract chain heads from the current fit state before replacing anything.
     fit_state = state.fitting.fit_state
+    heads = heads_logp = fitter_method = None
     if fit_state is not None and hasattr(fit_state, "Nvar"):
         new_nvar = len(fitProblem.getp())
         if new_nvar != fit_state.Nvar:
             raise ValueError(
-                f"Cannot keep chain state: new problem has {new_nvar} free "
-                f"parameters but the stored chain state has {fit_state.Nvar}. "
+                f"Cannot warm-start: new problem has {new_nvar} free parameters "
+                f"but the current chain state has {fit_state.Nvar}. "
                 f"Call set_serialized_problem() to start a fresh fit."
             )
+        heads, heads_logp = fit_state._last_gen()
+        heads = heads.copy()
+        heads_logp = heads_logp.copy()
+        Nvar = fit_state.Nvar
+        Npop = fit_state.Npop
+        fitter_method = state.fitting.method or "dream"
 
+    # Install the new problem.
     state.problem.fitProblem = fitProblem
     if name:
         fitProblem.name = name
     state.shared.updated_model = now_string()
     state.shared.updated_parameters = now_string()
+
+    # Replace fit_state with a minimal MCMCDraw carrying only the chain heads.
+    # Discarding the thinned history keeps the state small and avoids stale
+    # log-probability values from the old likelihood surface contaminating
+    # best-point tracking on the new problem.
+    if heads is not None:
+        Ncr = 3  # AdaptiveCrossover default; resize() will correct if needed
+        new_fit_state = MCMCDraw(1, 1, 1, Nvar, Npop, Ncr, 1)
+        new_fit_state._gen_current[:] = heads
+        new_fit_state._gen_current_logp[:] = heads_logp
+        # draws=Npop / generation=1: triggers the warm-start path in core.py
+        # (`if previous_draws: x, logp = state._last_gen()`) while leaving
+        # the full new sample budget available.
+        new_fit_state.draws = Npop
+        new_fit_state.generation = 1
+        # _best_logp from the old run is incommensurable with the new
+        # likelihood surface — reset so any new sample can claim the best.
+        new_fit_state._best_x = None
+        new_fit_state._best_logp = -_np.inf
+        state.set_fit_state(new_fit_state, method=fitter_method)
+        state.fitting.method = fitter_method
+
     state.autosave()
 
 

--- a/bumps/webview/server/api.py
+++ b/bumps/webview/server/api.py
@@ -426,57 +426,6 @@ async def load_session(pathlist: List[str], filename: str, read_only: bool = Fal
     state.shared.updated_parameters = now_string()
 
 
-def _rebuild_mcmc_state(old_fit_state: MCMCDraw, fitProblem, options: dict) -> MCMCDraw:
-    """Build a minimal MCMCDraw for a parameter space change (add/remove/reorder).
-
-    Uses ``bumps.initpop.generate`` with the stored fit options to produce a
-    correctly-sized population for the new problem (same pop scaling and init
-    strategy as DreamFit.solve).  Matched parameters then have their columns
-    overwritten with the old chain-head values.  New parameters keep the
-    generated values.
-
-    Returns a new MCMCDraw with draws=new_Npop so that _run_dream enters the
-    resume path, triggering nllf recompute and convergence delay.
-    """
-    from bumps.initpop import generate
-
-    old_labels = old_fit_state.labels
-    new_labels = fitProblem.labels()
-    old_x, _ = old_fit_state._last_gen()  # (old_Npop, old_Nvar)
-
-    # generate() handles pop scaling, init strategy, bounds, and use_point.
-    new_pop = generate(fitProblem, **options)  # (new_Npop, new_Nvar)
-    new_Npop, new_Nvar = new_pop.shape
-
-    # Override columns for parameters that survived from the old chain.
-    # np.resize tiles old rows to fill new_Npop (which may be larger, e.g. going
-    # from 1 to 2 parameters doubles the required population).  Duplicated rows
-    # diverge quickly via DE perturbations; this is preferable to leaving the
-    # extra rows as cold random draws from generate(), which would drag convergence.
-    old_label_to_col = {label: i for i, label in enumerate(old_labels)}
-    old_x_resized = np.resize(old_x, (new_Npop, old_x.shape[1]))
-    for new_col, label in enumerate(new_labels):
-        if label in old_label_to_col:
-            new_pop[:, new_col] = old_x_resized[:, old_label_to_col[label]]
-
-    Ncr = old_fit_state.Ncr
-    thinning = old_fit_state.thinning
-    new_state = MCMCDraw(1, 1, 1, new_Nvar, new_Npop, Ncr, thinning)
-    new_state._gen_current[:] = new_pop
-    # -inf logp_old causes metropolis to accept all proposals on the first DE step,
-    # ensuring real logp values are recorded before _best_x is needed by the monitor.
-    new_state._gen_current_logp[:] = -np.inf
-    # Guarantee state.best() returns a valid array; also lets _run_dream's nllf
-    # recompute at the top of the resume path evaluate a sensible starting point.
-    new_state._best_x = new_pop[0].copy()
-    new_state._best_logp = -np.inf
-    new_state.labels = new_labels
-    # draws=new_Npop > 0 makes previous_draws truthy in _run_dream
-    new_state.draws = new_Npop
-    new_state.generation = 1
-    return new_state
-
-
 @register
 async def update_serialized_problem(
     serialized: str,
@@ -486,16 +435,12 @@ async def update_serialized_problem(
     """Update the current FitProblem without resetting the fit state.
 
     Use this instead of ``set_serialized_problem`` when you want to resume
-    DREAM from the existing chain population rather than starting fresh.  On
-    the next ``start_fit_thread("dream", options, resume=True)`` call,
-    ``_run_dream`` will recompute nllf for all chain heads on the new
-    likelihood surface and defer the convergence test by one full buffer cycle.
+    DREAM from the existing chain population rather than starting fresh.
 
-    If the parameter labels are identical to the current chain state the full
-    chain history is preserved.  If labels have changed (parameters added,
-    removed, or renamed) a minimal MCMCDraw is built: matched parameters carry
-    their chain-head values forward; new parameters are seeded with LHS draws.
-    History is lost in this case but a cold start is avoided.
+    Parameter-space changes (parameters added, removed, or renamed) are handled
+    automatically on the next ``start_fit_thread("dream", options, resume=True)``
+    call: ``DreamFit.solve`` detects the label mismatch and rebuilds the chain
+    state via ``_rebuild_mcmc_state`` before sampling begins.
 
     Use ``set_serialized_problem()`` for a true cold start.
 
@@ -507,16 +452,8 @@ async def update_serialized_problem(
     # Deserialize the new problem first so we fail fast on bad input.
     fitProblem = deserialize_problem(serialized, method=method)
 
-    fit_state = state.fitting.fit_state
-    if fit_state is not None and hasattr(fit_state, "labels"):
-        new_labels = fitProblem.labels()
-        if fit_state.labels != new_labels:
-            # Parameter space has changed — rebuild a minimal MCMCDraw so that
-            # _run_dream still enters the resume path (nllf recompute + convergence delay).
-            new_fit_state = _rebuild_mcmc_state(fit_state, fitProblem, options=state.fitting.options)
-            state.set_fit_state(new_fit_state, method=state.fitting.method)
-
-    # Install the new problem; the existing (or rebuilt) fit_state is preserved.
+    # Install the new problem; the existing fit_state is preserved intact.
+    # Any parameter-space mismatch is resolved automatically by DreamFit.solve().
     state.problem.fitProblem = fitProblem
     if name:
         fitProblem.name = name


### PR DESCRIPTION
## Warm-start DREAM fits via the webview API

### Problem statement

Autonomous measurement systems (e.g. AutoRefl, active learning loops) refit a model after every new data point. With DREAM, each cold start discards all information from the previous run and re-draws the initial population from scratch, wasting burn-in time even though the posterior barely moves between iterations.

What is needed is a way for an external controller to:

1. Tell the server that the model has changed (new data injected).
2. Resume DREAM from the chain heads of the previous run rather than a fresh population.

The chain heads are the only information that matters for seeding the next run — the thinned sample history is not needed and becomes a liability (stale log-probability values from the old likelihood surface interfere with best-point tracking on the new problem).

### Requirements

- The controller must be able to replace the `FitProblem` with a new one (same parameters, additional data) without clearing the chain state.
- The degrees of freedom must be recomputed automatically from the new data — no manual update required.
- The payload sent between controller and server must remain small regardless of how many iterations have run or how many samples have been collected. The thinned chain history must not accumulate across iterations.
- If no prior fit state exists (first iteration), the system must fall back gracefully to a cold start.
- If the number of free parameters changes, the system should raise an error — chain heads are meaningless in a different parameter space. Note that in the future there may be use cases where this will be different: for example, adding a model to the fit with its own probe-specific parameters. This can probably be addressed at that point, or we just revert to a cold start.

---

### Implementation

#### New endpoint

**`prepare_warm_start(serialized, method="dataclass", name=None)`**

Replaces the current `FitProblem` (e.g. one with an additional data point) while retaining only the DREAM chain heads from the existing fit state, discarding the thinned sample history, convergence data, and stale log-probability values. The next `start_fit_thread("dream", options, resume=True)` call will seed the chain population from those heads.

The degrees of freedom are recomputed automatically from the new problem, so adding data points requires no manual dof update.

**Fallback behaviour:**
- If no prior fit state exists (first iteration), the chain-head installation is skipped and the subsequent `start_fit_thread` performs a normal cold start.
- If the number of free parameters in `serialized` differs from the current chain state, `ValueError` is raised — chain heads are meaningless in a different parameter space and a cold start via `set_serialized_problem` is required instead.

The `method` parameter carries the same deserialization caveat as `set_serialized_problem`: `"pickle"`, `"cloudpickle"`, and `"dill"` enable arbitrary code execution. The recommended and default method is `"dataclass"`.

#### Intended call sequence per iteration

```python
await sio.call("prepare_warm_start", serialized, "dataclass", name)
await sio.call("start_fit_thread", "dream", options, True)  # resume=True
```

This mirrors the existing cold-start pattern (`set_serialized_problem` + `start_fit_thread`). Fitter options (`samples`, `burn`, `pop`, etc.) are kept separate so they can vary independently of the problem setup.

#### Test

`test_warm_start.py` demonstrates the full loop: a simple Gaussian model with one free parameter (`A`, true value 3.0), adding one noisy data point per iteration. Iteration 1 is a cold start via `set_serialized_problem`; subsequent iterations call `prepare_warm_start` then `start_fit_thread(..., resume=True)`. The estimate of `A` converges toward 3.0 across iterations.

[test_warm_start.py](https://github.com/user-attachments/files/29349292/test_warm_start.py)
[warm_start_output.txt](https://github.com/user-attachments/files/29349293/warm_start_output.txt)