### PR TITLE
support zero width prior and posterior

### DIFF
--- a/bumps/bounds.py
+++ b/bumps/bounds.py
@@ -560,7 +560,9 @@ class Bounded(Bounds):
 
     def get01(self, x):
         lo, hi = self.limits
-        # TODO: check hi > lo during constructor
+        if lo >= hi:
+            # Return 50th percentile for all values if width is zero
+            return 0.5
         return clip(float(x - lo) / (hi - lo), 0, 1)
 
     def put01(self, v):

--- a/bumps/dream/parcoord.py
+++ b/bumps/dream/parcoord.py
@@ -81,7 +81,6 @@ def best_in_bin(x, value, bins=50, range=None, keep_empty=False):
     if (x == x[0]).all():
         x = value
 
-    print(x.shape, x.min(), x.max(), value.shape, value.min(), value.max())
     # Find the bin index for each coordinate value. This may put multiple
     # values in each bin, and some bins may be empty.
     if isinstance(bins, int):

--- a/bumps/dream/parcoord.py
+++ b/bumps/dream/parcoord.py
@@ -11,7 +11,7 @@ def plot(draw, nlines=150, control_var=None):
 
     If *control_var* is provided, then the best value from each bin in the
     histogram for that variable will be chosen as a line to draw on the
-    coordination plot. This will will produce a roughly equally spaced set of
+    coordination plot. This will produce a roughly equally spaced set of
     coordination points for that variable. If *control_var* is None, then
     lines will be picked at random.
     """
@@ -70,47 +70,52 @@ def best_in_bin(x, value, bins=50, range=None, keep_empty=False):
     This list may be shorter than the number of bins if *keep_empty* is False.
 
     The algorithm works by assigning a bin number to each point then adding
-    an offset in [0, 1) according to the scaled *value*.  These point values
+    an offset in [0, 0.99] according to the scaled *value*.  These point values
     are then sorted, and searched by bin number.  The returned index will
-    correspond to the first value in each bin, and therefore, the best value
+    correspond to the first value in each bin, and therefore, the lowest value
     in that bin.  From this the index into the original list can be returned.
     """
 
-    # Find bin number for each value.
+    # If all x are identical then bin by value instead of x. This will give
+    # a representative sample across the credible range.
+    if (x == x[0]).all():
+        x = value
+
+    print(x.shape, x.min(), x.max(), value.shape, value.min(), value.max())
+    # Find the bin index for each coordinate value. This may put multiple
+    # values in each bin, and some bins may be empty.
     if isinstance(bins, int):
         # Find intervals for x and use integer division to assign bin number.
         # Don't worry that this might create bin numbers such as -3 or nbins+5
         # since these will be ignored during bin lookup.
         xmin, xmax = range if range is not None else (np.min(x), np.max(x))
-        dx = (xmax - xmin) / bins
-        value_in_bin = (x - xmin) // dx if dx != 0.0 else np.full_like(x, bins // 2)
+        dx = (xmax - xmin) / (bins - 1)
+        bin_index = (x - xmin) // dx
         nbins = bins
     else:
         # Lookup x in bin edges. searchsorted returns index 0 for elements
         # before the first edge so we need to put an extra start edge and
         # subtract one from the index so that bin number is -1 before first.
-        value_in_bin = np.searchsorted(np.hstack((-np.inf, bins)), x) - 1
+        bin_index = np.searchsorted(np.hstack((-np.inf, bins)), x) - 1
         nbins = len(bins) - 1
 
-    # Increment bin number offset using scaled value.  Limit the scaled
-    # value to 0.99 rather 1.0 so that the worst value isn't 1.0, which
-    # will be the best value in the next bin.
-    value_in_bin += scale(value) * 0.99
+    # Adjust each index by value in [0.0, 0.99]
+    bin_index += zero_one_norm(value) * 0.99
 
-    # Sort values, preserving original indices
-    sort_index = np.argsort(value_in_bin)
-    sorted_value_in_bin = value_in_bin[sort_index]
+    # Sort the adjusted indices, preserving original
+    sort_index = np.argsort(bin_index)
+    sorted_bin_index = bin_index[sort_index]
 
     # Lookup first point in each bin, which will now by the min chisq in bin.
     bin_numbers = np.arange(nbins)
-    min_index = np.searchsorted(sorted_value_in_bin, bin_numbers)
+    min_index = np.searchsorted(sorted_bin_index[:-1], bin_numbers)
 
     # Find the point number for the best points in the original list.
     index = sort_index[min_index]
 
-    # Indentify empty bins. This will occur if base value returned by
+    # Identify empty bins. This will occur if base value returned by
     # search sorted does not match the bin number.
-    empty = np.floor(sorted_value_in_bin[min_index]) != bin_numbers
+    empty = np.floor(sorted_bin_index[min_index]) != bin_numbers
 
     # Process empty bins.
     if keep_empty:
@@ -143,7 +148,7 @@ def parallel_coordinates(data, labels=None, value=None, value_label=""):
         labels = ["p%d" % k for k in range(ndim)]
 
     x = np.arange(ndim)
-    data = scale(data, axis=0)
+    data = zero_one_norm(data, axis=0)
 
     # We need to set the plot limits, they will not autoscale
     fig, ax = plt.gcf(), plt.gca()
@@ -161,16 +166,16 @@ def parallel_coordinates(data, labels=None, value=None, value_label=""):
         plt.sci(lines)
 
 
-def scale(x, axis=None):
+def zero_one_norm(value, axis=None):
     """
     Returns *x* with values scaled to [0, 1].
 
     If *axis* is not None, then scale values within each axis independently,
     otherwise use the min/max value across all dimensions.
     """
-    low = x.min(axis=axis, keepdims=True)
-    high = x.max(axis=axis, keepdims=True)
-    dx = high - low
-    dx[dx == 0.0] = 1.0
-    scaled = (x - low) / dx
+    low = value.min(axis=axis, keepdims=True)
+    high = value.max(axis=axis, keepdims=True)
+    diff = high - low
+    diff[diff == 0.0] = 1.0  # If all values are the same, scaled will be all zeros.
+    scaled = (value - low) / diff
     return scaled

--- a/bumps/dream/varplot.py
+++ b/bumps/dream/varplot.py
@@ -168,7 +168,7 @@ def decorate_histogram(vstats, axes):
 
     # Put the parameter label on the line with mean and best markers. Use the side without
     # the mean/best marker so that they don't overwrite each other.
-    if (vstats.mean - l95) / (h95 - l95) > 0.4 or (vstats.best - l95) / (h95 - l95) > 0.4:
+    if h95 == l95 or (vstats.mean - l95) / (h95 - l95) > 0.4 or (vstats.best - l95) / (h95 - l95) > 0.4:
         x, ha = 0.02, "left"
     else:
         x, ha = 0.98, "right"

--- a/bumps/plots/varplot.py
+++ b/bumps/plots/varplot.py
@@ -101,9 +101,9 @@ def plot_var(fig: "go.Figure", draw: "Draw", vstats: "VarStats", var: int, cbar_
         showscale=showscale,
         subplot=subplot,
     )
-
-    fig["data"].extend(traces)
-    _decorate_histogram(vstats, fig, subplot=subplot)
+    if traces is not None:
+        fig["data"].extend(traces)
+        _decorate_histogram(vstats, fig, subplot=subplot)
 
 
 def _decorate_histogram(vstats: "VarStats", fig: dict, subplot: int = 1):
@@ -187,6 +187,10 @@ def _decorate_histogram(vstats: "VarStats", fig: dict, subplot: int = 1):
 
 def _make_logp_histogram(values, logp, nbins, ci, weights, idx, cbar_edges, showscale=False, subplot=None):
     from numpy import ones_like, searchsorted, linspace, cumsum, diff, unique, argsort, array, hstack, exp
+
+    # TODO: what to do when the posterior width is zero?
+    if ci[0] == ci[1]:
+        return
 
     if weights is None:
         weights = ones_like(logp)


### PR DESCRIPTION
Fixes #458

To test set `b.pmp(0)` in `curvefit/curve.py` and/or set `peak.A.pmp(0)` in `peaks/model.py`.

The quick fix to the plotly parameter histogram was to just not plot it when the posterior range was empty. It would be better to plot a normal histogram with the bar in the center. If it is not done as part of this PR then we should add this as an issue.
