### PR TITLE
Update emcee bumps wrapper to use np.trapezoid

### DIFF
--- a/extra/mc.py
+++ b/extra/mc.py
@@ -157,8 +157,8 @@ def log_evidence(logls, betas, fburnin=0.1):
     isort = np.argsort(betas)
     betas = betas[isort]
     mean_logls = mean_logls[isort]
-    lnZ = np.trapz(mean_logls, betas)
-    lnZ2 = np.trapz(mean_logls[::2], betas[::2])
+    lnZ = np.trapezoid(mean_logls, betas)
+    lnZ2 = np.trapezoid(mean_logls[::2], betas[::2])
 
     return lnZ, np.abs(lnZ - lnZ2)
 


### PR DESCRIPTION
np.trapz was removed in 2.4.0. The replacement, np.trapezoid, is in all currently supported versions of numpy, so we don't need to guard the import statements.

This only affects the emcee parallel tempering walker for bumps models implemented in `explore/mc.py`. It does not affect the installed bumps package.

Closes #463 