### PR TITLE
Use correct load_problem interface when reloading export

### DIFF
--- a/bumps/cli.py
+++ b/bumps/cli.py
@@ -951,7 +951,7 @@ def reload_export(
             raise ValueError(f"Model file has been modified. Copy {saved_model} into {modelfile.parent}")
 
         # Load the model script and the fitted values.
-        problem = load_problem(modelfile, model_options=args)
+        problem = load_problem(modelfile, args=args)
         load_pars(problem, parfile)
 
     # Load the MCMC files

--- a/bumps/fitproblem.py
+++ b/bumps/fitproblem.py
@@ -1084,7 +1084,7 @@ def load_problem(path: Path | str, args: list[str] | None = None):
     or a previously saved problem, serialized as .json, .cloudpickle, .pickle or .dill
 
     *args* are any additional arguments to the model.  The sys.argv
-    variable will be set such that *sys.argv[1:] == model_options*.
+    variable will be set such that *sys.argv[1:] == args*.
     """
     from .state import SERIALIZER_EXTENSIONS, deserialize_problem_bytes
 

--- a/bumps/nested.py
+++ b/bumps/nested.py
@@ -162,7 +162,7 @@ def main():
 
     print(opts)
     print(opts.modelfile)
-    problem = load_problem(opts.modelfile[0], model_options=opts.modelopts)
+    problem = load_problem(opts.modelfile[0], args=opts.modelopts)
     if opts.pars:
         load_pars(problem, opts.pars)
     sampler = Sampler(problem, opts.export)


### PR DESCRIPTION
When switching from old `cli.load_model(path, model_options=...)` to new `fitproblem.load_problem(path, args=...)` we changed  the function name in the call but not the argument name. As a result, reload export no longer worked.